### PR TITLE
Display kill score as a HUD element

### DIFF
--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -44,6 +44,9 @@ local function bounty_player(target)
 	end
 	bounty_score = math.floor(bounty_score)
 
+	ctf_stats.current_bounty["name"] = bountied_player
+	ctf_stats.current_bounty["score"] = bounty_score
+
 	minetest.after(0.1, announce_all)
 end
 
@@ -70,6 +73,7 @@ minetest.after(math.random(500, 1000), bounty_find_new_target)
 minetest.register_on_leaveplayer(function(player)
 	if bountied_player == player:get_player_name() then
 		bountied_player = nil
+		ctf_stats.current_bounty = {}
 	end
 end)
 
@@ -80,6 +84,10 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 ctf.register_on_killedplayer(function(victim, killer)
+	-- Suicide is not encouraged here at CTF
+	if victim == killer then
+		return
+	end
 	if victim == bountied_player then
 		local main, match = ctf_stats.player(killer)
 		if main and match then
@@ -88,6 +96,7 @@ ctf.register_on_killedplayer(function(victim, killer)
 			ctf.needs_save = true
 		end
 		bountied_player = nil
+		ctf_stats.current_bounty = {}
 
 		local msg = killer .. " has killed " .. victim .. " and received the prize!"
 		minetest.chat_send_all(msg)


### PR DESCRIPTION
- Kill score (in green) is displayed (as an HUD element) for `hud_duration` seconds.
- If kill is a bounty kill, bounty score (in red) is also displayed below the kill score, and is visible for the same `hud_duration` seconds.
- New table added: `ctf_stats.current_bounty`
  - Target name is stored in `ctf_stats.current_bounty["name"]`
  - Target score is stored in `ctf_stats.current_bounty["score"]`
  - When the target is killed, the table is set to `nil`
  - On selecting a new target, the table is updated

![Screenshot](https://user-images.githubusercontent.com/36130650/43520996-59c9ae1a-95b2-11e8-9afc-59c511c30524.png)

**Extensive testing required; _only_ the appearance of the HUD elements were tested by me (by means of a custom chat-command).**

### Discussion
- Is the placement of the HUD elements good enough?
- Is the size of the text alright? I personally prefer a larger font-size... ~is that possible?~

****
Closes #72 