### PR TITLE
Implement kill assists

### DIFF
--- a/mods/ctf/ctf_stats/gui.lua
+++ b/mods/ctf/ctf_stats/gui.lua
@@ -9,6 +9,7 @@ local tablecolumns = {
 	"text,width=6;",
 	"text,width=6;",
 	"text,width=6;",
+	"text,width=6;",
 	"text,width=6]"
 }
 tablecolumns = table.concat(tablecolumns, "")
@@ -99,7 +100,7 @@ function ctf_stats.get_formspec(title, players, header, hlt_name)
 	ret = ret .. tablecolumns
 	ret = ret .. "tableoptions[highlight=#00000000]"
 	ret = ret .. "table[0.5,0;13.25,6.1;scores;"
-	ret = ret .. "#ffffff,,Player,Kills,Deaths,K/D,Bounty Kills,Captures,Attempts,Score"
+	ret = ret .. "#ffffff,,Player,Kills,Deaths,K/D ratio,Bounty kills,Kill assists,Captures,Attempts,Score"
 
 	local player_in_top_50 = false
 
@@ -124,6 +125,7 @@ function ctf_stats.get_formspec(title, players, header, hlt_name)
 			  "," .. pstat.deaths ..
 			  "," .. math.floor(kd * 10) / 10  ..
 			  "," .. pstat.bounty_kills ..
+			  "," .. pstat.kill_assists ..
 			  "," .. pstat.captures ..
 			  "," .. pstat.attempts ..
 			  "," .. math.floor(pstat.score * 10) / 10


### PR DESCRIPTION
- All players dealing damage of more than 10 HP to an enemy within 30s of the kill will be awarded kill assist score, calculated by the following formula:

  `(damage_dealt / max_hp) * kill_reward`

  e.g. If a player assists by dealing a damage of 15HP and the victim's kill reward is taken to be 100, then the player will be awarded a score of 75 for the assist.

- The killer will still receive the full reward.
- The `kill_assists` table will be reset on a new match. `kill_assists[name]` will be reset on death of `name`, after all kill assists have been awarded.
- The death of a player doesn't affect their previous kill assists.

Requires thorough testing.

Closes #184