### PR TITLE
Fix summary not stored before restart

### DIFF
--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -1,6 +1,3 @@
-local storage = minetest.get_mod_storage()
-local prev_match_summary = storage:get_string("prev_match_summary")
-
 -- Formspec element that governs table columns and their attributes
 local tablecolumns = {
 	"tablecolumns[color;",
@@ -85,10 +82,6 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 	ret = ret .. "label[10.5,0.5;Total score]"
 	ret = ret .. "label[12,0.5;" .. render_team_stats(red, blue, "score", true) .. "]"
 	ret = ret .. "label[2,7.75;Tip: type /rankings for league tables]"
-
-	-- Set prev_match_summary and write to mod_storage
-	prev_match_summary = ret
-	storage:set_string("prev_match_summary", ret)
 
 	return ret
 end
@@ -373,16 +366,5 @@ minetest.register_chatcommand("transfer_rankings", {
 		ctf.needs_save = true
 
 		return true, "Stats of '" .. src .. "' have been transferred to '" .. dest .. "'."
-	end
-})
-
-minetest.register_chatcommand("summary", {
-	description = "Display the scoreboard of the previous match.",
-	func = function (name, param)
-		if not prev_match_summary then
-			return false, "Couldn't find the requested data."
-		end
-
-		minetest.show_formspec(name, "ctf_stats:prev_match_summary", prev_match_summary)
 	end
 })


### PR DESCRIPTION
- Match summary is now shown at the end of the going match (using `registered_on_winner` and `register_on_skip_map` callbacks), instead of at the start of the next match.
- Therefore, `prev_match_summary` is now preserved even after restart.
- Also fixes the "Can't initialize mod storage twice" error which occurred due to mod storage also being initialized in `gui.lua` to set/get summary from mod storage. Now, the code for storing and retrieving `prev_match_summary` has been moved to init.lua itself.

**Tested - works as intended**