### PR TITLE
Made vauge text in team chest more specific

### DIFF
--- a/mods/ctf_team_base/chest.lua
+++ b/mods/ctf_team_base/chest.lua
@@ -74,10 +74,10 @@ for _, chest_color in pairs(colors) do
 
 			if is_pro then
 				formspec = formspec .. "listring[current_name;pro]" ..
-					"label[5,-0.2;" .. minetest.formspec_escape("Pro players only (1k+ score, good KD)") .. "]"
+					"label[5,-0.2;" .. minetest.formspec_escape("Pro players only (1k+ score, 1.5+ KD)") .. "]"
 			else
 				formspec = formspec .. "listring[current_name;pro]" ..
-					"label[5,-0.2;" .. minetest.formspec_escape("You need 1k+ score and good KD") .. "]"
+					"label[5,-0.2;" .. minetest.formspec_escape("You need 1k+ score and 1.5+ KD") .. "]"
 			end
 
 			formspec = formspec ..


### PR DESCRIPTION
Previously the only way to know that 1.5 KD was considered good enough to be pro, you had to see the random message `Access the pro section of the chest by achieving a 1k+ score and killing 3 people for every 2 deaths.`

Now "1k+ score and good KD" is replaced with "1k+ score and 1.5+ KD"