### PR TITLE
Increase player movement speed

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -10,6 +10,17 @@ sprint_stamina = 5
 enable_lavacooling = false
 
 #
+# Player physics
+#
+
+movement_acceleration_default = 5
+movement_acceleration_air = 3
+movement_speed_walk = 6
+movement_speed_crouch = 2
+movement_speed_jump = 7
+movement_liquid_fluidity = 1.25
+
+#
 # CTF_PVP_ENGINE
 # See mods/ctf_pvp_engine/minetest.conf.example for ctf_pvp_engine settings.
 #


### PR DESCRIPTION
CTF is a fast-paced PvP game, and Minetest's default player speeds are too slow for this game in my opinion. This PR aims to improve player speed to a level which suits CTF.

Tested, requires feedback. Video showcase: https://youtu.be/yBNhx5J_V_4