### PR TITLE
Add ceiling and bedrock during barrier placement

### DIFF
--- a/mods/ctf_map/barrier.lua
+++ b/mods/ctf_map/barrier.lua
@@ -183,6 +183,30 @@ function ctf_map.place_outer_barrier(center, r, h)
 		end
 	end
 
+	print("Placing bedrock")
+
+	-- Bedrock
+	do
+		local y = minp.y
+		for x = minp.x, maxp.x do
+			for z = minp.z, maxp.z do
+				data[a:index(x, y, z)] = c_stone
+			end
+		end
+	end
+
+	print("Placing ceiling")
+
+	-- Ceiling
+	do
+		local y = maxp.y
+		for x = minp.x, maxp.x do
+			for z = minp.z, maxp.z do
+				data[a:index(x, y, z)] = c_glass
+			end
+		end
+	end
+
 	print("Writing to engine!")
 
 	vm:set_data(data)


### PR DESCRIPTION
- Adds an `ind_glass` ceiling and an `ind_stone` bedrock.
- Will prevent cheese-holes in the bottom of the map and would save map makers the effort of having to patch up all of those holes.

Tested. Video demonstration: https://youtu.be/ZA5PMhQ5-M8