### PR TITLE
Trivial bug-fix and new chat-command for a quick peek at one's own score

### DIFF
--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -253,6 +253,13 @@ local function send_as_chat_result(to, name)
 	return true, result
 end
 
+minetest.register_chatcommand("r", {
+	description = "Display your rankings as a chat result.",
+	func = function(name, param)
+		return send_as_chat_result(name, name)
+	end
+})
+
 minetest.register_chatcommand("rankings", {
 	params = "[<name>]",
 	description = "Display rankings of yourself or another player.",


### PR DESCRIPTION
- Fixes `/rankings` chat-command not returning score as chat output in the absence of player object.
- Adds new chat-command `/r` which can be used to quickly see one's own score without having a massive formspec obstructing the screen. Should this be extended to support displaying scores of other players too? To clarify: it'd then be the same as passing a player name to `/rankings` in the olden times. ;)

![screenshot_20181112_204250](https://user-images.githubusercontent.com/36130650/48356665-c51c3380-e6bc-11e8-8986-5858350a2fad.png)
