### PR TITLE
Fix EOM shown before winner_player is initialized

### DIFF
--- a/mods/ctf_stats/init.lua
+++ b/mods/ctf_stats/init.lua
@@ -142,7 +142,7 @@ end)
 local winner_team = "-"
 local winner_player = "-"
 
-ctf_flag.register_on_capture(function(name, flag)
+table.insert(ctf_flag.registered_on_capture, 1, function(name, flag)
 	local main, match = ctf_stats.player(name)
 	if main and match then
 		main.captures  = main.captures  + 1
@@ -162,7 +162,7 @@ ctf_match.register_on_winner(function(winner)
 
 	-- Show match summary
 	local fs = ctf_stats.get_formspec_match_summary(ctf_stats.current,
-					winner_team, winner_player, os.time()-ctf_stats.start)
+					winner_team, winner_player, os.time() - ctf_stats.start)
 	for _, player in pairs(minetest.get_connected_players()) do
 		minetest.show_formspec(player:get_player_name(), "ctf_stats:eom", fs)
 	end


### PR DESCRIPTION
#### Issue

Players reported that the name of the flag-capturer wasn't shown in the End-of-Match formspec.
![issue](https://cdn.discordapp.com/attachments/447819018028449793/512515947647467527/screenshot_20181115_120529.png)

#### Cause

The `register_on_winner` callbacks are called from a `register_on_capture` in `ctf_match/matches.lua` after checking that there are no other teams left. But `winner_player` is also initialized in another `register_on_capture` callback in `ctf_stats/init.lua`. I'm guessing the callback in `ctf_match/matches.lua` is always executed first, because `ctf_stats` has a hard dependency on `ctf_match`. So the EOM formspec is shown before the winner player can be initialized, resulting in a `-` being shown.

#### Solution (albeit a hacky one)

The fix is to just insert the callback in `ctf_stats/init.lua` at the beginning of `ctf_flag.registered_on_capture` instead of appending it to the end. Tested.

![screenshot_20181115_144849](https://user-images.githubusercontent.com/36130650/48544039-cc278980-e8e8-11e8-9ff4-7972f15a6e72.png)