### PR TITLE
Improve crafting recipe of ladder_wood

### DIFF
--- a/mods/ctf_crafting/init.lua
+++ b/mods/ctf_crafting/init.lua
@@ -110,8 +110,8 @@ crafting.register_recipe({
 
 crafting.register_recipe({
 	type   = "inv",
-	output = "default:ladder 5",
-	items  = { "default:stick 7" },
+	output = "default:ladder 4",
+	items  = { "default:stick 8" },
 	always_known = true,
 	level  = 1,
 })


### PR DESCRIPTION
Closes #249 

Current: 7 sticks -> 5 ladders
Proposed: 8 sticks -> 4 ladders

The new recipe suggested in https://github.com/MT-CTF/capturetheflag/issues/249#issuecomment-439640263, also makes the recipes truly reversible.