### PR TITLE
Fix missing field: default.node_sound_snow_defaults

### DIFF
--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -828,7 +828,11 @@ stairs.register_stair_and_slab(
 	{"default_snow.png"},
 	"Snow Block Stair",
 	"Snow Block Slab",
-	default.node_sound_snow_defaults(),
+	default.node_sound_dirt_defaults({
+		footstep = {name = "default_snow_footstep", gain = 0.15},
+		dug = {name = "default_snow_footstep", gain = 0.2},
+		dig = {name = "default_snow_footstep", gain = 0.2}
+	}),
 	true
 )
 


### PR DESCRIPTION
Replaces `default.node_sound_snow_defaults()` method with the following taken from node-def of `default:snow`:

```lua
default.node_sound_dirt_defaults({
	footstep = {name = "default_snow_footstep", gain = 0.15},
	dug = {name = "default_snow_footstep", gain = 0.2},
	dig = {name = "default_snow_footstep", gain = 0.2}
})
```

Fixes #261 