### PR TITLE
Add a 'x' minute temporary lockout feature when vote kicked

### DIFF
--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -339,12 +339,12 @@ if set == nil or minetest.is_yes(set) then
 						minetest.chat_send_all("Vote passed, " ..
 								#results.yes .. " to " .. #results.no .. ", " ..
 								self.name .. " will be kicked.")
-						minetest.kick_player(self.name, "The vote to kick you passed. You have been temporarily banned for 10 minutes")
+						minetest.kick_player(self.name, "The vote to kick you passed.\n You have been temporarily banned for 10 minutes.")
 						-- after player kick
-					vlist[self.name].locked = true
+						vlist[self.name].locked = true
 						minetest.after(600, function()
-					vlist[self.name] = nil
-					end)
+							vlist[self.name] = nil
+						end)
 					else
 						minetest.chat_send_all("Vote failed, " ..
 								#results.yes .. " to " .. #results.no .. ", " ..

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -339,12 +339,12 @@ if set == nil or minetest.is_yes(set) then
 						minetest.chat_send_all("Vote passed, " ..
 								#results.yes .. " to " .. #results.no .. ", " ..
 								self.name .. " will be kicked.")
-						minetest.kick_player(self.name, "The vote to kick you passed")	
+						minetest.kick_player(self.name, "The vote to kick you passed")
 						-- after player kick
 					vlist[self.name].locked = true
-  						minetest.after(600, function()
- 					vlist[self.name] = nil
-                    			end)
+						minetest.after(600, function()
+					vlist[self.name] = nil
+					end)
 					else
 						minetest.chat_send_all("Vote failed, " ..
 								#results.yes .. " to " .. #results.no .. ", " ..
@@ -370,7 +370,7 @@ minetest.register_on_joinplayer(function(player)
         }
     end
 end)
- 
+
 minetest.register_on_prejoinplayer(function(name, ip)
     if vlist[name] and vlist[name].locked then
         return "Please wait until the vote cool down period has elapsed before rejoining!"
@@ -382,7 +382,7 @@ minetest.register_on_prejoinplayer(function(name, ip)
         end
     end
 end)
- 
+
 minetest.register_on_leaveplayer(function(player)
     local name = player:get_player_name()
     if not vlist[name].locked then

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -339,7 +339,7 @@ if set == nil or minetest.is_yes(set) then
 						minetest.chat_send_all("Vote passed, " ..
 								#results.yes .. " to " .. #results.no .. ", " ..
 								self.name .. " will be kicked.")
-						minetest.kick_player(self.name, "The vote to kick you passed.You will be temporarily banned for 10 minutes")
+						minetest.kick_player(self.name, "The vote to kick you passed. You will be temporarily banned for 10 minutes")
 						-- after player kick
 					vlist[self.name].locked = true
 						minetest.after(600, function()

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -220,8 +220,8 @@ minetest.register_on_leaveplayer(function(player)
 	local name = player:get_player_name()
 	vote.hud.players[name] = nil
 	if not vlist[name].locked then
-	vlist[name] = nil
-end
+		vlist[name] = nil
+	end
 end)
 
 function vote.update_all_hud()

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -383,7 +383,8 @@ minetest.register_on_prejoinplayer(function(name, ip)
 	else
 		for k, v in pairs(vlist) do
 			if v.ip == ip and v.locked then
-				return "You can't bypass the cool down by changing name!"
+				return "This IP has been temporarily blocked.".. 
+					"Please wait until the cool-down period has elapsed before rejoining."
 			end
 		end
 	end

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -345,8 +345,8 @@ if set == nil or minetest.is_yes(set) then
 						minetest.chat_send_all("Vote passed, " ..
 								#results.yes .. " to " .. #results.no .. ", " ..
 								self.name .. " will be kicked.")
-						minetest.kick_player(self.name, 
-							("The vote to kick you passed.\n You have been temporarily banned" .. 
+						minetest.kick_player(self.name,
+							("The vote to kick you passed.\n You have been temporarily banned" ..
 							" for %s minutes."):format(tostring(vote.kick_cooldown / 60)))
 						vlist[self.name].locked = true
 						minetest.after(vote.kick_cooldown, function()

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -381,7 +381,7 @@ minetest.register_on_prejoinplayer(function(name, ip)
 	if vlist[name] and vlist[name].locked then
 		return "Please wait until the vote cool down period has elapsed before rejoining!"
 	else
-		for k,v in pairs(vlist) do
+		for k, v in pairs(vlist) do
 			if v.ip == ip and v.locked then
 				return "You can't bypass the cool down by changing name!"
 			end

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -217,11 +217,11 @@ function vote.update_hud(player)
 	end
 end
 minetest.register_on_leaveplayer(function(player)
-        local name = player:get_player_name()
+		local name = player:get_player_name()
 		vote.hud.players[name] = nil
 		if not vlist[name].locked then
-		vlist[name] = nil
-	end
+			vlist[name] = nil
+		end
 end)
 
 function vote.update_all_hud()
@@ -377,7 +377,7 @@ minetest.register_on_joinplayer(function(player)
         }
     end
 end)
- minetest.register_on_prejoinplayer(function(name, ip)
+minetest.register_on_prejoinplayer(function(name, ip)
     if vlist[name] and vlist[name].locked then
         return "Please wait until the vote cool down period has elapsed before rejoining!"
     else

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -339,7 +339,7 @@ if set == nil or minetest.is_yes(set) then
 						minetest.chat_send_all("Vote passed, " ..
 								#results.yes .. " to " .. #results.no .. ", " ..
 								self.name .. " will be kicked.")
-						minetest.kick_player(self.name, "The vote to kick you passed. You will be temporarily banned for 10 minutes")
+						minetest.kick_player(self.name, "The vote to kick you passed. You have been temporarily banned for 10 minutes")
 						-- after player kick
 					vlist[self.name].locked = true
 						minetest.after(600, function()

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -384,7 +384,7 @@ minetest.register_on_prejoinplayer(function(name, ip)
 		for k, v in pairs(vlist) do
 			if v.ip == ip and v.locked then
 				return "This IP has been temporarily blocked.".. 
-					"Please wait until the cool-down period has elapsed before rejoining."
+					" Please wait until the cool-down period has elapsed before rejoining."
 			end
 		end
 	end

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -383,7 +383,7 @@ minetest.register_on_prejoinplayer(function(name, ip)
 	else
 		for k, v in pairs(vlist) do
 			if v.ip == ip and v.locked then
-				return "This IP has been temporarily blocked.".. 
+				return "This IP has been temporarily blocked."..
 					" Please wait until the cool-down period has elapsed before rejoining."
 			end
 		end

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -217,11 +217,11 @@ function vote.update_hud(player)
 	end
 end
 minetest.register_on_leaveplayer(function(player)
-		local name = player:get_player_name()
-		vote.hud.players[name] = nil
-		if not vlist[name].locked then
-			vlist[name] = nil
-		end
+	local name = player:get_player_name()
+	vote.hud.players[name] = nil
+	if not vlist[name].locked then
+	vlist[name] = nil
+end
 end)
 
 function vote.update_all_hud()

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -378,13 +378,13 @@ minetest.register_on_joinplayer(function(player)
     end
 end)
 minetest.register_on_prejoinplayer(function(name, ip)
-    if vlist[name] and vlist[name].locked then
-        return "Please wait until the vote cool down period has elapsed before rejoining!"
-    else
-        for k,v in pairs(vlist) do
-            if v.ip == ip and v.locked then
-                return "You can't bypass the cool down by changing name!"
-            end
-        end
-    end
+	if vlist[name] and vlist[name].locked then
+		return "Please wait until the vote cool down period has elapsed before rejoining!"
+	else
+		for k,v in pairs(vlist) do
+			if v.ip == ip and v.locked then
+				return "You can't bypass the cool down by changing name!"
+			end
+		end
+	end
 end)

--- a/mods/vote/init.lua
+++ b/mods/vote/init.lua
@@ -339,7 +339,7 @@ if set == nil or minetest.is_yes(set) then
 						minetest.chat_send_all("Vote passed, " ..
 								#results.yes .. " to " .. #results.no .. ", " ..
 								self.name .. " will be kicked.")
-						minetest.kick_player(self.name, "The vote to kick you passed")
+						minetest.kick_player(self.name, "The vote to kick you passed.You will be temporarily banned for 10 minutes")
 						-- after player kick
 					vlist[self.name].locked = true
 						minetest.after(600, function()


### PR DESCRIPTION
When a player is kicked he/she is locked out from joining until x minutes are completed
This acts as a temporary ban

All credit goes to shivajiva 

closes #265 