### PR TITLE
Bounty announcement and persistence improvements

### DIFF
--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -67,15 +67,11 @@ local function bounty_find_new_target()
 end
 minetest.after(math.random(500, 1000), bounty_find_new_target)
 
-minetest.register_on_leaveplayer(function(player)
-	if bountied_player == player:get_player_name() then
-		bountied_player = nil
-	end
-end)
-
 minetest.register_on_joinplayer(function(player)
-	if bountied_player then
-		announce(player:get_player_name())
+	local name = player:get_player_name()
+	if bountied_player and
+			bountied_player ~= name then
+		announce(name)
 	end
 end)
 

--- a/mods/ctf_bounties/init.lua
+++ b/mods/ctf_bounties/init.lua
@@ -21,10 +21,7 @@ local function announce_all()
 end
 
 local function bounty_player(target)
-	if bountied_player then
-		minetest.chat_send_all("Player " .. bountied_player .. " no longer has a bounty on their head!")
-	end
-
+	local prev = bountied_player
 	bountied_player = target
 
 	--                Score * K/D
@@ -43,6 +40,19 @@ local function bounty_player(target)
 		bounty_score = 50
 	end
 	bounty_score = math.floor(bounty_score)
+
+	if prev then
+		for _, player in pairs(minetest.get_connected_players()) do
+			local name = player:get_player_name()
+			if bountied_player ~= name then
+				local _, prev_color = ctf_colors.get_color(prev, ctf.player(prev))
+				minetest.chat_send_player(player:get_player_name(),
+					minetest.colorize("#fff326", "Player ") ..
+					minetest.colorize(prev_color:gsub("0x", "#"), prev) ..
+					minetest.colorize("#fff326", " no longer has a bounty on their head!"))
+			end
+		end
+	end
 
 	minetest.after(0.1, announce_all)
 end


### PR DESCRIPTION
This PR aims to plug a couple of minor loopholes in the `bounties` mod
- Bounty is not removed when target leaves, and players would still be able to kill the target. This prevents player from relogging to rid themselves of the prize on their head.
- Previous bounty expiration messages (`Player <name> no longer has a bounty on their head!`) will not be sent to the current target, preventing them from knowing that they're the current target.