### PR TITLE
Add maps as submodule in mods/ctf_maps/maps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "mods/crafting"]
 	path = mods/crafting
 	url = https://github.com/rubenwardy/crafting
+[submodule "mods/ctf_map/maps"]
+	path = mods/ctf_map/maps
+	url = https://github.com/MT-CTF/maps.git


### PR DESCRIPTION
This allows `capturetheflag` to be playable right off the bat without having to manually add maps to the mods/ctf_map/maps dir.