### PR TITLE
Allow .git in mods/ctf_map/maps dir

### DIFF
--- a/mods/ctf_map/schem_map.lua
+++ b/mods/ctf_map/schem_map.lua
@@ -58,7 +58,8 @@ local function search_for_maps()
 				if extension == "mts" then
 					files_hash[dir .. "/" .. filename] = true
 				else
-					if extension ~= "conf" and extension ~= "md" then
+					if extension ~= "conf" and extension ~= "md"
+							and files[i] ~= ".git" then
 						error("Map extension is not '.mts': " .. files[i])
 					end
 				end


### PR DESCRIPTION
Very trivial, checks if `filename == ".git"` before throwing `"Map extension is not '.mts': <name>"` load-time error. Fixes #275 