### PR TITLE
Make tsm_chests:chest indestructible

### DIFF
--- a/mods/other/tsm_chests/init.lua
+++ b/mods/other/tsm_chests/init.lua
@@ -33,7 +33,7 @@ minetest.register_node("tsm_chests:chest", {
 	tiles = {"default_chest_top.png", "default_chest_top.png", "default_chest_side.png",
 		"default_chest_side.png", "default_chest_side.png", "default_chest_front.png"},
 	paramtype2 = "facedir",
-	groups = {choppy = 2, oddly_breakable_by_hand = 2},
+	groups = {immortal = 1},
 	legacy_facedir_simple = true,
 	is_ground_content = false,
 	sounds = default.node_sound_wood_defaults(),


### PR DESCRIPTION
Chests are already unbreakable by tools when their inventory is non-empty. I suggest making them completely indestructible. Note that they will automatically disappear when their inventory is empty.

**Untested**. This fixes #278 since guns respect item groups.