### PR TITLE
Use LVM to place schems, fixed previously encountered lighting bugs

### DIFF
--- a/mods/ctf_map/barrier.lua
+++ b/mods/ctf_map/barrier.lua
@@ -51,7 +51,7 @@ function ctf_map.remove_middle_barrier()
 	end
 
 	vm:set_data(data)
-	vm:write_to_map(data)
+	vm:write_to_map()
 	vm:update_map()
 end
 

--- a/mods/ctf_map/schem_map.lua
+++ b/mods/ctf_map/schem_map.lua
@@ -23,8 +23,8 @@ minetest.register_alias("default:bush_leaves", "air")
 minetest.register_alias("default:bush_stem", "air")
 minetest.register_alias("default:stone_with_gold", "default:stone")
 
-
 local max_r  = 120
+local max_h  = 150
 local mapdir = minetest.get_modpath("ctf_map") .. "/maps/"
 ctf_map.map  = nil
 
@@ -89,50 +89,48 @@ minetest.register_chatcommand("maps_reload", {
 
 
 function ctf_map.place_map(map)
-	ctf_map.emerge_with_callbacks(nil, map.pos1, map.pos2, function()
-		local schempath = mapdir .. map.schematic
-		local res = minetest.place_schematic(map.pos1, schempath,
-				map.rotation == "z" and "0" or "90")
+	local schempath = mapdir .. map.schematic
 
-		assert(res)
+	--------------------------------------------------
+	-- LVM
 
-		for _, value in pairs(ctf_map.map.teams) do
-			ctf_team_base.place(value.color, value.pos)
+	local vm  = minetest.get_voxel_manip(map.pos1, map.pos2)
+	local res = minetest.place_schematic_on_vmanip(vm, map.pos1, schempath,
+			map.rotation == "z" and "0" or "90")
+
+	assert(res)
+
+	vm:write_to_map()
+
+	--------------------------------------------------
+
+	for _, value in pairs(ctf_map.map.teams) do
+		ctf_team_base.place(value.color, value.pos)
+	end
+
+	local seed = minetest.get_mapgen_setting("seed")
+	for _, chestzone in pairs(ctf_map.map.chests) do
+		minetest.log("warning", "Placing " .. chestzone.n .. " chests from " ..
+				minetest.pos_to_string(chestzone.from) .. " to "..
+				minetest.pos_to_string(chestzone.to))
+		place_chests(chestzone.from, chestzone.to, seed, chestzone.n)
+	end
+
+	minetest.after(2, function()
+		local msg = "Map: " .. map.name .. " by " .. map.author
+		if map.hint then
+			msg = msg .. "\n" .. map.hint
 		end
-
-		local seed = minetest.get_mapgen_setting("seed")
-		for _, chestzone in pairs(ctf_map.map.chests) do
-			minetest.log("warning", "Placing " .. chestzone.n .. " chests from " ..
-					minetest.pos_to_string(chestzone.from) .. " to "..
-					minetest.pos_to_string(chestzone.to))
-			place_chests(chestzone.from, chestzone.to, seed, chestzone.n)
+		minetest.chat_send_all(msg)
+		if minetest.global_exists("irc") and irc.connected then
+			irc:say("Map: " .. map.name)
 		end
-
-		minetest.after(2, function()
-			local msg = "Map: " .. map.name .. " by " .. map.author
-			if map.hint then
-				msg = msg .. "\n" .. map.hint
-			end
-			minetest.chat_send_all(msg)
-			if minetest.global_exists("irc") and irc.connected then
-				irc:say("Map: " .. map.name)
-			end
-		end)
-
-		minetest.after(10, function()
-			minetest.fix_light(ctf_map.map.pos1, ctf_map.map.pos2)
-		end)
-	end, nil)
+	end)
 end
 
 function ctf_match.load_map_meta(idx, name)
 	local offset = vector.new(600 * idx, 0, 0)
-	local conf_path = mapdir .. name .. ".conf"
-	local meta   = Settings(conf_path)
-
-	if meta:get("r") == nil then
-		error("Map was not properly configured " .. conf_path)
-	end
+	local meta = Settings(mapdir .. name .. ".conf")
 
 	local initial_stuff = meta:get("initial_stuff")
 	local map = {
@@ -150,10 +148,10 @@ function ctf_match.load_map_meta(idx, name)
 		chests        = {},
 	}
 
-	assert(map.r <= max_r)
+	assert(map.r <= max_r and map.h <= max_h)
 
 	map.pos1 = vector.add(offset, { x = -map.r, y = -map.h / 2, z = -map.r })
-	map.pos2 = vector.add(offset, { x =  map.r, y = map.h / 2,  z =  map.r })
+	map.pos2 = vector.add(offset, { x =  map.r, y =  map.h / 2, z =  map.r })
 
 	-- Read teams from config
 	local i = 1

--- a/mods/ctf_map/schem_map.lua
+++ b/mods/ctf_map/schem_map.lua
@@ -1,4 +1,4 @@
-assert(minetest.get_mapgen_setting("mg_name") == "singlenode", "singlenode mapgen is required.")
+minetest.set_mapgen_params({mgname = "singlenode", flags = "nolight"})
 
 minetest.register_alias("mapgen_singlenode", "ctf_map:ignore")
 minetest.register_alias("ctf_map:flag", "air")
@@ -24,7 +24,6 @@ minetest.register_alias("default:bush_stem", "air")
 minetest.register_alias("default:stone_with_gold", "default:stone")
 
 local max_r  = 120
-local max_h  = 150
 local mapdir = minetest.get_modpath("ctf_map") .. "/maps/"
 ctf_map.map  = nil
 
@@ -91,23 +90,25 @@ minetest.register_chatcommand("maps_reload", {
 function ctf_map.place_map(map)
 	local schempath = mapdir .. map.schematic
 
-	--------------------------------------------------
-	-- LVM
-
+	--
+	-- Place schematic
+	--
 	local vm  = minetest.get_voxel_manip(map.pos1, map.pos2)
 	local res = minetest.place_schematic_on_vmanip(vm, map.pos1, schempath,
 			map.rotation == "z" and "0" or "90")
-
 	assert(res)
-
 	vm:write_to_map()
 
-	--------------------------------------------------
-
+	--
+	-- Create bases
+	--
 	for _, value in pairs(ctf_map.map.teams) do
 		ctf_team_base.place(value.color, value.pos)
 	end
 
+	--
+	-- Place flags
+	--
 	local seed = minetest.get_mapgen_setting("seed")
 	for _, chestzone in pairs(ctf_map.map.chests) do
 		minetest.log("warning", "Placing " .. chestzone.n .. " chests from " ..
@@ -116,6 +117,9 @@ function ctf_map.place_map(map)
 		place_chests(chestzone.from, chestzone.to, seed, chestzone.n)
 	end
 
+	--
+	-- Wait then send map messages (avoids "X joined blue" spam)
+	--
 	minetest.after(2, function()
 		local msg = "Map: " .. map.name .. " by " .. map.author
 		if map.hint then
@@ -148,7 +152,7 @@ function ctf_match.load_map_meta(idx, name)
 		chests        = {},
 	}
 
-	assert(map.r <= max_r and map.h <= max_h)
+	assert(map.r <= max_r)
 
 	map.pos1 = vector.add(offset, { x = -map.r, y = -map.h / 2, z = -map.r })
 	map.pos2 = vector.add(offset, { x =  map.r, y =  map.h / 2, z =  map.r })

--- a/mods/ctf_map/schem_map.lua
+++ b/mods/ctf_map/schem_map.lua
@@ -1,4 +1,4 @@
-minetest.set_mapgen_params({mgname = "singlenode", flags = "nolight"})
+minetest.set_mapgen_setting("mgname", "singlenode")
 
 minetest.register_alias("mapgen_singlenode", "ctf_map:ignore")
 minetest.register_alias("ctf_map:flag", "air")


### PR DESCRIPTION
See https://github.com/MT-CTF/capturetheflag/issues/169#issuecomment-442464397 and https://github.com/MT-CTF/capturetheflag/issues/169#issuecomment-442484605. The fix seems to be surprisingly trivial. I hope lighting bugs don't pop-up after this gets merged...

#### Summary
I began experimenting with LVM schem placement again, and only encountered lighting bugs in the form of a dark strip in the middle where the barrier was. This is because https://github.com/MT-CTF/capturetheflag/commit/ae8005a1f40adba733710888f4662e31957b8ed9 set the default mapgen light level to 0. The result was the post barrier placement, the lighting was re-calculated with respect to 0, creating a dark strip across the middle. The fix is to just change that mapgen param to `light` or omit it altogether, as `light` is the default.

![screenshot](https://user-images.githubusercontent.com/36130650/49161593-2d227900-f34f-11e8-9d6e-e4bb65f070f4.png)

****

Tested over and over again, but further testing on other devices isn't a bad thing, especially when lighting bugs popped up all over the map in spite of all that testing for #167...

Fixes #169, closes #281, and closes #100