### PR TITLE
Don't award points for suicide and disable player damage in shooter during buildtime

### DIFF
--- a/mods/ctf_stats/init.lua
+++ b/mods/ctf_stats/init.lua
@@ -286,6 +286,10 @@ local function calculateKillReward(victim, killer)
 end
 
 ctf.register_on_killedplayer(function(victim, killer)
+	-- Suicide is not encouraged here at CTF
+	if victim == killer then
+		return
+	end
 	local main, match = ctf_stats.player(killer)
 	if main and match then
 		local reward = calculateKillReward(victim, killer)

--- a/mods/shooter/shooter.lua
+++ b/mods/shooter/shooter.lua
@@ -42,6 +42,15 @@ if singleplayer then
 	SHOOTER_ALLOW_PLAYERS = false
 end
 
+if minetest.global_exists("ctf_match") then
+	ctf_match.register_on_build_time_start(function()
+		SHOOTER_ALLOW_PLAYERS = false
+	end)
+	ctf_match.register_on_build_time_end(function()
+		SHOOTER_ALLOW_PLAYERS = true
+	end)
+end
+
 local modpath = minetest.get_modpath(minetest.get_current_modname())
 local worldpath = minetest.get_worldpath()
 local input = io.open(modpath.."/shooter.conf", "r")


### PR DESCRIPTION
Follow-up to c7a8998. Suicide using grenades counts as one kill and two deaths. Committing suicide will ruin one's K/D but will also provide a big boost to their score, by as much as 200 points.

Another relevant issue, introduced in b30ea67, allows a player to commit suicide without actually dying. Since PvP isn't disable now, a player can drop a grenade on themselves. `shooter` will immediately call `obj:punch` within `shooter.blast`, which in turn calls the `on_punchplayer` callbacks. There are two conflicting callbacks:
- One introduced in b30ea67, that prevents damage during buildtime
- Another one in `mods/ctf_pvp_engine/ctf/teams.lua` that handles the `on_killedplayer` callbacks.

The first callback prevents the player from dying, but the second callback registers a kill and executes all `on_killedplayer` callbacks even though the player hasn't yet died.

This PR tackles both the issues by:
- Returning from the `on_killedplayer` callback in `mods/ctf_stats/init.lua` to prevent awarding points for the kill, and to prevent registering incorrect stats.
- Disabling `SHOOTER_ENABLE_PLAYER` during buildtime start and re-enabling it during buildtime end.