### PR TITLE
Add physics modifiers wrapper mod for player physics overrides

### DIFF
--- a/mods/other/sprint/depends.txt
+++ b/mods/other/sprint/depends.txt
@@ -1,2 +1,3 @@
 medkits
+physics
 hudbars?

--- a/mods/other/sprint/init.lua
+++ b/mods/other/sprint/init.lua
@@ -7,10 +7,6 @@ local MOD_JUMP    = tonumber(minetest.settings:get("sprint_jump")      or 1.1)
 local STAMINA_MAX = tonumber(minetest.settings:get("sprint_stamina")   or 20)
 local HEAL_RATE   = tonumber(minetest.settings:get("sprint_heal_rate") or 0.5)
 local MIN_SPRINT  = tonumber(minetest.settings:get("sprint_min")       or 0.5)
-local SPRINT_MODIFIERS = {
-	[true]  = { speed = MOD_WALK, jump = MOD_JUMP },
-	[false] = { speed = 1.0,      jump = 1.0      },
-}
 
 if minetest.get_modpath("hudbars") ~= nil then
 	hb.register_hudbar("sprint", 0xFFFFFF, "Stamina",
@@ -27,7 +23,14 @@ local players = {}
 
 local function setSprinting(player, info, sprinting)
 	if info.sprinting ~= sprinting then
-		player:set_physics_override(SPRINT_MODIFIERS[sprinting])
+		if sprinting then
+			physics.set(player:get_player_name(), "sprint:sprint", {
+				speed = MOD_WALK,
+				jump  = MOD_JUMP
+			})
+		else
+			physics.remove(player:get_player_name(), "sprint:sprint")
+		end
 		info.sprinting = sprinting
 	end
 end

--- a/mods/physics/init.lua
+++ b/mods/physics/init.lua
@@ -1,0 +1,47 @@
+physics = {}
+
+local players = {}
+
+minetest.register_on_joinplayer(function(player)
+	players[player:get_player_name()] = {}
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	players[player:get_player_name()] = nil
+end)
+
+local function update(name)
+	assert(players[name])
+	local player = minetest.get_player_by_name(name)
+	local override = {
+		speed   = 1,
+		jump    = 1,
+		gravity = 1
+	}
+
+	for _, layer in pairs(players[name]) do
+		for attr, val in pairs(layer) do
+			override[attr] = override[attr] * val
+		end
+	end
+
+	player:set_physics_override(override)
+end
+
+function physics.set(pname, name, modifiers)
+	assert(players[pname] and not players[pname][name])
+	players[pname][name] = modifiers
+	update(pname)
+end
+
+function physics.change(pname, name, modifier)
+	assert(players[pname] and players[pname][name])
+	players[pname][name] = modifier
+	update(pname)
+end
+
+function physics.remove(pname, name)
+	assert(players[pname] and players[pname][name])
+	players[pname][name] = nil
+	update(pname)
+end


### PR DESCRIPTION
This PR adds the `physics` mod, which allows cohesive modification of player physics without the need for mods to interface with each other, with support for addressing each modifier individually. The basic code is in, but I'm yet to add some documentation. There are three main parts to this mod:

`sprint` has been updated to use the API methods of `physics` instead of directly managing player physics overrides.

- `physics.set(pname, name, modifiers)`: Set modifier to a player.
  - `pname`: Player name.
  - `name`: Arbitrary name to identify the modifier.
  - `modifiers`: A table of modifiers.
- `physics.change(pname, name, modifiers)`: Edit modifier of player on the fly.
  - `pname`: Player name.
  - `name`: Name of modifier to be replaced, passed to `physics.set`.
  - `modifiers`: Replacement modifier table.
- `physics.remove(pname, name)`: Remove modifier from a player.
  - `pname`: Player name.
  - `name`: Name of modifier to be removed, passed to `physics.set`.
- `update(name)`: Re-calculate accumulated physics modifiers and update a player's physics overrides
  - `name`: Player name.

`update` is a local function invoked by both `physics.set`, `physics.change`, and `physics.remove` after adding or removing a modifier respectively.

Here's some example code used by sprint to add the sprint modifiers:
```lua
if sprinting then
	physics.set(player:get_player_name(), "sprint:sprint", {
		speed = MOD_WALK,  -- MOD_WALK defaults to 1.8
		jump  = MOD_JUMP   -- MOD_JUMP defaults to 1.1
	})
else
	physics.remove(player:get_player_name(), "sprint:sprint")
end
```

Tested - https://youtu.be/1TfQ8XzqsMU. Closes #288 

