### PR TITLE
Fix and improve /reset_rankings

### DIFF
--- a/mods/ctf_stats/gui.lua
+++ b/mods/ctf_stats/gui.lua
@@ -323,20 +323,31 @@ minetest.register_chatcommand("reset_rankings", {
 	description = "Reset the rankings of yourself or another player",
 	func = function(name, param)
 		param = param:trim()
-		if param ~= "" and not minetest.check_player_privs(name, { ctf_admin = true}) then
+		if param ~= "" and not minetest.check_player_privs(name, {ctf_admin = true}) then
 			return false, "Missing privilege: ctf_admin"
 		end
 
 		local reset_name = param == "" and name or param
 
+		if not ctf_stats.players[reset_name] then
+			return false, "Player '" .. reset_name .. "' does not exist."
+		end
+
 		if reset_name == name and not reset_y[name] then
 			reset_y[name] = true
-			return true, "This will reset your stats and rankings completely. You will lose access to any special privileges such as the team chest or userlimit skip. This is irreversable. If you're sure, type /reset_rankings again to perform the reset"
+			minetest.after(30, function()
+				reset_y[name] = nil
+			end)
+			return true, "This will reset your stats and rankings completely."
+				.. " You will lose access to any special privileges such as the"
+				.. " team chest or userlimit skip. This is irreversable. If you're"
+				.. " sure, re-type /reset_rankings within 30 seconds to reset."
 		end
 		reset_y[name] = nil
 
-		ctf_stats.players[name] = nil
+		ctf_stats.players[reset_name] = nil
 		ctf_stats.player(reset_name)
+		ctf.needs_save = true
 		return true, "Successfully reset the stats and ranking of " .. reset_name
 	end
 })


### PR DESCRIPTION
- Adds `ctf.needs_save = true`
- To confirm resetting own rank, one has to re-type `/reset_rankings` within 30 seconds. This timeout is just in case someone "accidentally" entered this command, and wants to abort.
- The bug that was actually the reason one couldn't reset the rankings of someone else:
  - The param is being checked against `""` but it's the caller's rankings that actually got reset
```lua
	local reset_name = param == "" and name or param
	ctf_stats.players[name] = nil
```

Tested