### PR TITLE
Add `hud_score` mod API

### DIFF
--- a/mods/ctf/ctf_bounties/depends.txt
+++ b/mods/ctf/ctf_bounties/depends.txt
@@ -1,3 +1,3 @@
 ctf
 ctf_stats
-irc?
+hud_score

--- a/mods/ctf/ctf_bounties/init.lua
+++ b/mods/ctf/ctf_bounties/init.lua
@@ -86,26 +86,27 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 ctf.register_on_killedplayer(function(victim, killer)
-	-- Suicide is not encouraged here at CTF
-	if victim == killer then
+	if victim ~= bountied_player or victim == killer then
 		return
 	end
-	if victim == bountied_player then
-		local main, match = ctf_stats.player(killer)
-		if main and match then
-			main.score  = main.score  + bounty_score
-			match.score = match.score + bounty_score
-			ctf.needs_save = true
-		end
-		bountied_player = nil
 
-		local msg = killer .. " has killed " .. victim .. " and received the prize!"
-		minetest.chat_send_all(msg)
-
-		local pstats, mstats = ctf_stats.player(killer)
-		pstats.bounty_kills = pstats.bounty_kills + 1
-		mstats.bounty_kills = mstats.bounty_kills + 1
+	local main, match = ctf_stats.player(killer)
+	if main and match then
+		main.score  = main.score  + bounty_score
+		match.score = match.score + bounty_score
+		main.bounty_kills = main.bounty_kills + 1
+		match.bounty_kills = match.bounty_kills + 1
+		ctf.needs_save = true
 	end
+	bountied_player = nil
+
+	local msg = killer .. " has killed " .. victim .. " and received the prize!"
+	minetest.chat_send_all(msg)
+	hud_score.new(killer, {
+		name = "ctf_bounty:prize",
+		color = 0x4444FF,
+		value = bounty_score
+	})
 end)
 
 minetest.register_privilege("bounty_admin")

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -299,6 +299,14 @@ ctf.register_on_killedplayer(function(victim, killer)
 		match.score = match.score + reward
 		match.kills_since_death = match.kills_since_death + 1
 		ctf.needs_save = true
+
+		reward = math.floor(reward * 100) / 100
+
+		hud_score.new(killer, {
+			name = "ctf_stats:kill_score",
+			color = "0x00FF00",
+			value = reward
+		})
 	end
 end)
 

--- a/mods/pvp/hud_score/README.md
+++ b/mods/pvp/hud_score/README.md
@@ -1,0 +1,47 @@
+# `hud_score`
+
+`hud_score` provides an API to display HUD score elements which can be used to
+display kill scores, bounty scores, etc.
+
+## Methods
+
+- `hud_score.new(name, score_def)`: Adds a new HUD score element to player `name`.
+  - `name` [string]: Player name
+  - `score_def` [table]: HUD score element definition. See below.
+
+## HUD score element definition
+
+HUD score element definition table, passed to `hud_score.new`.
+
+Example definition:
+
+```lua
+{
+    name  = "ctf_stats:kill_score", -- Can be any arbitrary string
+    color = "0x00FF00",             -- Should be compatible with Minetest's HUD def
+    value = 50,                     -- The actual number to be displayed
+    -- Field `time` is automatically added by `hud_score.new`
+    -- to keep track of element expiry
+}
+```
+
+## `players` table
+
+This is a table of tables, indexed by player names. This table holds the HUD
+data of all online players. Each sub-table is a list of score tables, which
+are added by `hud_score.new`.
+
+```lua
+local players = {
+    ["name"] = {
+        [1] = <score_def>,
+        [2] = <score_def>,
+        [3] = <score_def>
+        ...
+    },
+    ["name2"] = {
+        ...
+    },
+    ...
+}
+```

--- a/mods/pvp/hud_score/init.lua
+++ b/mods/pvp/hud_score/init.lua
@@ -1,0 +1,102 @@
+hud_score = {}
+local hud = hudkit()
+
+local players = {}
+local duration = 5
+local max = 6
+
+local function update(name)
+	local player = minetest.get_player_by_name(name)
+	if not player then
+		return
+	end
+
+	-- Handle all elements marked for deletion
+	-- and rebuild table
+	local temp = {}
+	for _, def in ipairs(players[name]) do
+		if def.delete then
+			if hud:exists(player, def.name) then
+				hud:remove(player, def.name)
+			end
+		else
+			table.insert(temp, def)
+		end
+	end
+
+	for i, def in ipairs(temp) do
+		-- If not the top-most element, prefix with "+ "
+		local text = def.value
+		if i > 1 then
+			text = "+ " .. text
+		end
+
+		if hud:exists(player, def.name) then
+			hud:change(player, def.name, "text", text)
+			hud:change(player, def.name, "offset", {x = 0, y = i * 20})
+		else
+			hud:add(player, def.name, {
+				hud_elem_type = "text",
+				alignment = {x = 0, y = 0},
+				position = {x = 0.5, y = 0.6},
+				offset = {x = 0, y = i * 20},
+				number = def.color,
+				text = text
+			})
+		end
+	end
+	players[name] = temp
+end
+
+function hud_score.new(name, def)
+	local player = minetest.get_player_by_name(name)
+	if not player then
+		return
+	end
+
+	-- Verify HUD score element def
+	if not name or not def or type(def) ~= "table" or
+			not def.name or not def.value or not def.color then
+		error("hud_score: Invalid HUD score element definition", 2)
+	end
+
+	-- Store element expiration time in def.time
+	-- and append score element def to players[name]
+	def.time = os.time() + duration
+	table.insert(players[name], def)
+
+	-- If more than `max` active elements, mark oldest element for deletion
+	if #players[name] > max then
+		players[name][1].delete = true
+	end
+
+	update(name)
+end
+
+local modified
+minetest.register_globalstep(function(dtime)
+	-- Loop through HUD score elements of all players
+	-- and remove them if they've expired
+	for name, hudset in pairs(players) do
+		modified = false
+		for i, def in pairs(hudset) do
+			if def.time < os.time() then
+				def.delete = true
+				modified = true
+			end
+		end
+
+		-- If a player's hudset was modified, update player's HUD
+		if modified then
+			update(name)
+		end
+	end
+end)
+
+minetest.register_on_joinplayer(function(player)
+	players[player:get_player_name()] = {}
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	players[player:get_player_name()] = nil
+end)

--- a/mods/pvp/hud_score/mod.conf
+++ b/mods/pvp/hud_score/mod.conf
@@ -1,0 +1,3 @@
+name = hud_score
+description = API for displaying scores on HUD
+depends = hudkit


### PR DESCRIPTION
Replaces #240, with a generic API usable by mods.

### API

- `hud_score.new`: This is the only one method exposed to mods. This method takes a HUD score element definition as param, see "HUD score element definition" section below.
  - It adds the HUD element def to the player's list of HUD score elements, and calls an internal API function `update(name)` which updates all the HUD score elements of `name`.
  - If the number of HUD score elements exceeds 6, the oldest one will be marked for deletion.
- A globalstep takes care of expired elements by "marking" them for deletion, and calling `update`.

### HUD Score element definition

Here's an example table (taken from README.md):

```lua
{
    name  = "ctf_stats:kill_score",
    color = "0x00FF00",
    value = 50,   
    -- Field `time` is automatically added by `hud_score.new`
    -- to keep track of element expiry
}
```

### Testing code

```lua
minetest.register_chatcommand("test_hud", {
	func = function(name)
		local colors = {
			0x00FF00,
			0x0000FF,
			0xFF0000,
			0xFFFF00
		}

		hud_score.new(name, {
			name = "hud_score:debug_" .. math.random(65535),
			color = colors[math.random(1, 4)],
			value = math.random(50, 500)
		})
	end
})
```

****

Passed tests; everything works as it should. Closes #72 