### PR TITLE
Make kills-list display up to 12 kills

### DIFF
--- a/mods/ctf_events/init.lua
+++ b/mods/ctf_events/init.lua
@@ -4,7 +4,7 @@ minetest.register_on_leaveplayer(function(player)
 	hud.players[player:get_player_name()] = nil
 end)
 
-local NUM_EVT = 6
+local NUM_EVT = 12
 
 ctf_events = {
 	events = {}


### PR DESCRIPTION
Increases max no. of kills displayed from 6 to 12. Among other use-cases, this helps better with catching spawn-killers, as there's a huge difference between 6 and 12 kills in a row.

Tested. Doesn't interfere with the chat, even on screens with high DPI (phones and tablets, for example).

Here's the code I used for testing:
```lua
minetest.register_chatcommand("test", {
	func = function()
		for i = 1, 10 do
			ctf_events.post("kill_sword", "PlayerA", "PlayerB")
		end
		ctf_events.update_all()
	end
})
```