### PR TITLE
Replenish stamina on respawn

### DIFF
--- a/mods/sprint/init.lua
+++ b/mods/sprint/init.lua
@@ -111,8 +111,11 @@ minetest.register_on_joinplayer(function(player)
 		})
 	end
 
-
 	players[player:get_player_name()] = info
+end)
+
+minetest.register_on_respawnplayer(function(player)
+	players[player:get_player_name()].stamina = STAMINA_MAX
 end)
 
 minetest.register_on_leaveplayer(function(player)


### PR DESCRIPTION
Just noticed that a player's stamina isn't replenished on respawn. I've never come across this before - I can swear that I've respawned with full stamina every single time, even if I died right after I used up my sprint. But looking at the code, I don't see any code that replenishes player stamina on respawn. This simple PR just adds a couple of lines of code that replenishes player's stamina on respawn.