### PR TITLE
map_maker.lua: Fix missing assignment of return value

### DIFF
--- a/mods/ctf_map/map_maker.lua
+++ b/mods/ctf_map/map_maker.lua
@@ -31,7 +31,7 @@ end
 if flag_positions == "" then
 	flag_positions = {}
 else
-	minetest.parse_json(storage:get("flags"))
+	flag_positions = minetest.parse_json(storage:get("flags"))
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Super-trivial PR to fix a clumsy mistake on my part, introduced in def3b99 - If the key `flags` exists in mod storage, `parse_json` is invoked, but the value returned (the parsed table) isn't assigned back to `flag_positions`.