### PR TITLE
Reduce flag drop-time from 7 minutes to 5 minutes

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -21,6 +21,7 @@ ctf.flag.capture_take = true
 ctf.flag.waypoints = true
 ctf.flag.nobuild_radius = 3
 ctf.flag.alerts = true
+ctf.flag.drop_time = 300
 
 ctf.allocate_mode = 3
 ctf.diplomacy = false


### PR DESCRIPTION
The `ctf.flag.drop_time` setting has just been over-ridden in `minetest.conf`. Helps with deterring players who hold the flag without capturing.