### PR TITLE
Allocate players into teams on the basis of cumulative team scores

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -24,7 +24,7 @@ ctf.flag.nobuild_radius = 3
 ctf.flag.alerts = true
 ctf.flag.drop_time = 300
 
-ctf.allocate_mode = 3
+ctf.allocate_mode = 4
 ctf.players_can_change_team = false
 ctf.friendly_fire = false
 ctf.autoalloc_on_joinplayer = true


### PR DESCRIPTION
- `ctf.autoalloc` mode is set to 4 in `minetest.conf`. (MT-CTF/ctf_pvp_engine#30)
- `ctf.custom_alloc` function is overridden in `ctf_alloc/init.lua`.
- Cumulative team scores are tracked and updated on each player join and leave.
- Team with lowest cumulative score is stored separately, and is updated if required, when a player joins or leaves the team.
- `ctf.custom_alloc` just returns the name of the team with the lowest cumulative score (which has already been calculated).
- `ctf_alloc.set_all` (for mass alloc of all online players at start of new match) is only modified to call `calc_scores()`, which updates the cumulative scores of all teams.

I've also added a bunch of print statements to help with debugging, which I'll remove/convert to proper minetest.log calls before merging.

I've tested this PR (final test results [here](https://github.com/MT-CTF/capturetheflag/pull/319#issuecomment-541403715)) and it works, but it could do with more testing. Closes #315.