### PR TITLE
Add alternate furnace recipe

### DIFF
--- a/mods/ctf_crafting/init.lua
+++ b/mods/ctf_crafting/init.lua
@@ -78,6 +78,14 @@ crafting.register_recipe({
 
 crafting.register_recipe({
 	type   = "inv",
+	output = "default:furnace",
+	items  = { "default:desert_cobble 8" },
+	always_known = true,
+	level  = 1,
+})
+
+crafting.register_recipe({
+	type   = "inv",
 	output = "doors:door_steel",
 	items  = { "default:steel_ingot 6" },
 	always_known = true,
@@ -168,14 +176,6 @@ crafting.register_recipe({
 	type   = "inv",
 	output = "shooter:ammo 1",
 	items  = { "default:steel_ingot 3", "default:coal_lump 2" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:furnace",
-	items  = { "default:desert_cobble 8" },
 	always_known = true,
 	level  = 1,
 })

--- a/mods/ctf_crafting/init.lua
+++ b/mods/ctf_crafting/init.lua
@@ -171,3 +171,11 @@ crafting.register_recipe({
 	always_known = true,
 	level  = 1,
 })
+
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:furnace",
+	items  = { "default:desert_cobble 8" },
+	always_known = true,
+	level  = 1,
+})


### PR DESCRIPTION
Trivial PR
Adds alternate furnace recipe that requires desert cobblestone so as to fit with the maps that contain desert cobblestone such as The Bridge and Desert Spikes or those that may contain desert cobblestone in the future