### PR TITLE
Extend /summary to show scores of current match as well

### DIFF
--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -1,7 +1,12 @@
 ctf_stats = {}
 
 local storage = minetest.get_mod_storage()
+local prev_match_summary = storage:get_string("prev_match_summary")
 local data_to_persist = { "matches", "players" }
+
+function ctf_stats.get_prev_match_summary()
+	return prev_match_summary
+end
 
 function ctf_stats.load_legacy()
 	local file = io.open(minetest.get_worldpath() .. "/ctf_stats.txt", "r")
@@ -154,7 +159,6 @@ table.insert(ctf_flag.registered_on_capture, 1, function(name, flag)
 	winner_player = name
 end)
 
-local prev_match_summary = storage:get_string("prev_match_summary")
 ctf_match.register_on_winner(function(winner)
 	ctf.needs_save = true
 	ctf_stats.matches.wins[winner] = ctf_stats.matches.wins[winner] + 1
@@ -220,7 +224,6 @@ ctf_flag.register_on_precapture(function(name, flag)
 	return true
 end)
 
--- good_weapons now includes all mese and diamond implements, and swords of steel and better
 local good_weapons = {
 	"default:sword_steel",
 	"default:sword_bronze",
@@ -274,7 +277,7 @@ local function calculateKillReward(victim, killer)
 	end
 
 	-- Half if no good weapons
-	local inv = minetest.get_inventory({ type="player", name = victim })
+	local inv = minetest.get_inventory({ type = "player", name = victim })
 	if not invHasGoodWeapons(inv) then
 		ctf.log("ctf_stats", "Player " .. victim .. " has no good weapons")
 		reward = reward * 0.5
@@ -313,15 +316,36 @@ minetest.register_on_dieplayer(function(player)
 end)
 
 minetest.register_chatcommand("summary", {
-	func = function (name, param)
-		if not prev_match_summary then
-			return false, "Couldn't find the requested data."
-		end
+	func = function(name)
+		local fs = ctf_stats.get_formspec_match_summary(ctf_stats.current,
+						winner_team, winner_player, os.time() - ctf_stats.start)
 
-		minetest.show_formspec(name, "ctf_stats:prev_match_summary", prev_match_summary)
+		fs = fs .. "button[6,7.5;4,1;b_prev;<< Previous match]"
+
+		minetest.show_formspec(name, "ctf_stats:match_summary", fs)
 	end
 })
 
+minetest.register_on_player_receive_fields(function(player, formname, fields)
+	if formname ~= "ctf_stats:match_summary" then
+		return
+	end
+
+	local fs
+	if fields.b_prev then
+		fs = prev_match_summary
+		fs = fs .. "button[6,7.5;4,1;b_curr;Current match >>]"
+	elseif fields.b_curr then
+		fs = ctf_stats.get_formspec_match_summary(ctf_stats.current,
+					winner_team, winner_player, os.time() - ctf_stats.start)
+		fs = fs .. "button[6,7.5;4,1;b_prev;<< Previous match]"
+	else
+		return
+	end
+
+	minetest.show_formspec(player:get_player_name(), "ctf_stats:match_summary", fs)
+end)
+
 ctf_stats.load()
 
-dofile(minetest.get_modpath("ctf_stats").."/gui.lua")
+dofile(minetest.get_modpath("ctf_stats") .. "/gui.lua")

--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -27,17 +27,18 @@ function table.random( t ) -- luacheck: ignore
 end
 
 function random_messages.initialize() --Set the interval in minetest.conf.
-	minetest.settings:set("random_messages_interval",60)
+	minetest.settings:set("random_messages_interval", 60)
 	minetest.settings:write();
 	return 60
 end
 
 function random_messages.set_interval() --Read the interval from minetest.conf and set it if it doesn't exist
-	MESSAGE_INTERVAL = tonumber(minetest.settings:get("random_messages_interval")) or random_messages.initialize()
+	MESSAGE_INTERVAL = tonumber(minetest.settings:get("random_messages_interval"))
+							or random_messages.initialize()
 end
 
 function random_messages.check_params(name,func,params)
-	local stat,msg = func(params)
+	local stat, msg = func(params)
 	if not stat then
 		minetest.chat_send_player(name,msg)
 		return false
@@ -69,7 +70,8 @@ function random_messages.read_messages()
 		"Excessive spawn-killing is a direct violation of the rules - appropriate punishments will be given.",
 		"Use /r to check your score and rank, and /rankings to see the league tables.",
 		"Use bandages on team-mates to heal them by 3-4 HP if their health is below 15 HP.",
-		"Use /m to add a team marker at pointed location, that's visible only to team-mates."
+		"Use /m to add a team marker at pointed location, that's visible only to team-mates.",
+		"Use /summary to check scores of the current match or the previous match."
 	}
 end
 


### PR DESCRIPTION
![screenshot_20190109_215649](https://user-images.githubusercontent.com/36130650/50955280-b1375700-14de-11e9-8fa8-bbc2a853e8b0.png)
![screenshot_20190109_215652](https://user-images.githubusercontent.com/36130650/50955281-b1375700-14de-11e9-96b6-3713a96fe895.png)

- `/summary` can now display the scores of the current match in addition to the previous match summary.
  - The button to the left of `Close` can be used to switch between the two pages.
- `prev_match_summary` can be retrieved using the `ctf_stats.get_prev_match_summary` (to allow other files to access this var. See https://github.com/MT-CTF/capturetheflag/issues/313#issuecomment-452619913)

Closes #310. Tested.