### PR TITLE
Reorder crafting recipes to display more important recipes on first page

### DIFF
--- a/mods/ctf_crafting/init.lua
+++ b/mods/ctf_crafting/init.lua
@@ -1,11 +1,12 @@
 local full_ores = {
-	{"stone", "default:cobble"},
-	{"steel", "default:steel_ingot"},
-	{"bronze", "default:bronze_ingot"},
-	{"mese", "default:mese_crystal"},
 	{"diamond", "default:diamond"},
+	{"mese", "default:mese_crystal"},
+	{"bronze", "default:bronze_ingot"},
+	{"steel", "default:steel_ingot"},
+	{"stone", "default:cobble"},
 }
 
+-- Swords
 for _, orex in pairs(full_ores) do
 	crafting.register_recipe({
 		type   = "inv",
@@ -16,14 +17,7 @@ for _, orex in pairs(full_ores) do
 	})
 end
 
-crafting.register_recipe({
-	type   = "inv",
-	output = "shooter:arrow_white 5",
-	items  = { "default:stick 5", "default:cobble" },
-	always_known = true,
-	level  = 1,
-})
-
+-- Pickaxes
 for _, orex in pairs(full_ores) do
 	crafting.register_recipe({
 		type   = "inv",
@@ -33,6 +27,125 @@ for _, orex in pairs(full_ores) do
 		level  = 1,
 	})
 end
+
+-- Bronze ingot x9 <== Copper x9 + Tin x9
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:bronze_ingot 9",
+	items  = { "default:copper_ingot 8", "default:tin_ingot"},
+	always_known = true,
+	level  = 1,
+})
+
+-- Mese crystal x9 <== Mese block
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:mese_crystal 9",
+	items  = { "default:mese"},
+	always_known = true,
+	level  = 1,
+})
+
+-- Furnace <== Cobble x8
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:furnace",
+	items  = { "default:cobble 8" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Furnace <== Desert cobble x8
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:furnace",
+	items  = { "default:desert_cobble 8" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Team door
+crafting.register_recipe({
+	type   = "inv",
+	output = "doors:door_steel",
+	items  = { "default:steel_ingot 6" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Wooden plank x4
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:wood 4",
+	items  = { "group:tree" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Stick x4
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:stick 4",
+	items  = { "default:wood" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Torch x5
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:torch 5",
+	items  = { "default:stick", "default:coal_lump" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Ammo <== Tin ingot x3 + Coal lump x2
+crafting.register_recipe({
+	type   = "inv",
+	output = "shooter:ammo",
+	items  = { "default:tin_ingot 3", "default:coal_lump 2" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Ammo <== Steel ingot x3 + Coal lump x2
+crafting.register_recipe({
+	type   = "inv",
+	output = "shooter:ammo",
+	items  = { "default:steel_ingot 3", "default:coal_lump 2" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Arrow x5
+crafting.register_recipe({
+	type   = "inv",
+	output = "shooter:arrow_white 5",
+	items  = { "default:stick 5", "default:cobble" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Wooden ladder x4
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:ladder 4",
+	items  = { "default:stick 8" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Stick x2 <== Wooden ladder
+crafting.register_recipe({
+	type   = "inv",
+	output = "default:stick 2",
+	items  = { "default:ladder" },
+	always_known = true,
+	level  = 1,
+})
+
+-- Shovels
 for _, orex in pairs(full_ores) do
 	crafting.register_recipe({
 		type   = "inv",
@@ -42,6 +155,8 @@ for _, orex in pairs(full_ores) do
 		level  = 1,
 	})
 end
+
+-- Axes
 for _, orex in pairs(full_ores) do
 	crafting.register_recipe({
 		type   = "inv",
@@ -52,86 +167,7 @@ for _, orex in pairs(full_ores) do
 	})
 end
 
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:bronze_ingot 9",
-	items  = { "default:copper_ingot 8", "default:tin_ingot"},
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:mese_crystal 9",
-	items  = { "default:mese"},
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:furnace",
-	items  = { "default:cobble 8" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:furnace",
-	items  = { "default:desert_cobble 8" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "doors:door_steel",
-	items  = { "default:steel_ingot 6" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:wood 4",
-	items  = { "group:tree" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:stick 4",
-	items  = { "default:wood" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:torch 5",
-	items  = { "default:stick", "default:coal_lump" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:ladder 4",
-	items  = { "default:stick 8" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:stick 2",
-	items  = { "default:ladder" },
-	always_known = true,
-	level  = 1,
-})
-
+-- Wooden plank x3 <== Wooden pickaxe
 crafting.register_recipe({
 	type   = "inv",
 	output = "default:wood 3",
@@ -140,6 +176,7 @@ crafting.register_recipe({
 	level  = 1,
 })
 
+-- Wooden plank x2 <== Wooden sword
 crafting.register_recipe({
 	type   = "inv",
 	output = "default:wood 2",
@@ -148,6 +185,7 @@ crafting.register_recipe({
 	level  = 1,
 })
 
+-- Wooden plank x3 <== Wooden axe
 crafting.register_recipe({
 	type   = "inv",
 	output = "default:wood 3",
@@ -156,26 +194,11 @@ crafting.register_recipe({
 	level  = 1,
 })
 
+-- Wooden plank <== Wooden shovel
 crafting.register_recipe({
 	type   = "inv",
 	output = "default:wood 1",
 	items  = { "default:shovel_wood" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "shooter:ammo 1",
-	items  = { "default:tin_ingot 3", "default:coal_lump 2" },
-	always_known = true,
-	level  = 1,
-})
-
-crafting.register_recipe({
-	type   = "inv",
-	output = "shooter:ammo 1",
-	items  = { "default:steel_ingot 3", "default:coal_lump 2" },
 	always_known = true,
 	level  = 1,
 })


### PR DESCRIPTION
Also added comments to enhance readability.

Proposed order of crafting recipes:
- Swords (diamond to stone)
- Pickaxes (diamond to stone)
- Bronze ingot
- Mese block -> Mese crystals
- Cobble/Desert cobble -> Furnace
- Team door
- Tree -> Wooden planks
- Wooden plank -> Sticks
- Torch
- Tin/Steel ingot + Coal -> Ammo
- Arrows
- Wooden ladder
- Wooden ladder -> Sticks
- Shovels (diamond to stone)
- Axes (diamond to stone)
- Wooden tools -> Wooden planks