### PR TITLE
Combine furnace recipes; use group:stone as input

### DIFF
--- a/mods/ctf/ctf_crafting/init.lua
+++ b/mods/ctf/ctf_crafting/init.lua
@@ -46,20 +46,11 @@ crafting.register_recipe({
 	level  = 1,
 })
 
--- Furnace <== Cobble x8
+-- Furnace <== group:stone x8
 crafting.register_recipe({
 	type   = "inv",
 	output = "default:furnace",
-	items  = { "default:cobble 8" },
-	always_known = true,
-	level  = 1,
-})
-
--- Furnace <== Desert cobble x8
-crafting.register_recipe({
-	type   = "inv",
-	output = "default:furnace",
-	items  = { "default:desert_cobble 8" },
+	items  = { "group:stone 8" },
 	always_known = true,
 	level  = 1,
 })


### PR DESCRIPTION
There are only 9 nodes that come under `group:stone`. And `crafting` supports providing a group name as input. So, yay.

Closes #339 