### PR TITLE
Reduce width of name column in scores formspec

### DIFF
--- a/mods/ctf/ctf_stats/gui.lua
+++ b/mods/ctf/ctf_stats/gui.lua
@@ -2,7 +2,7 @@
 local tablecolumns = {
 	"tablecolumns[color;",
 	"text;",
-	"text,width=20;",
+	"text,width=16;",
 	"text,width=4;",
 	"text,width=4;",
 	"text,width=4;",


### PR DESCRIPTION
The current width results in the last 2-3 columns being clipped out on low DPI displays. This PR reduces the width of the name column by 4 slots, from 20 to 16.

Tested. The largest possible name with 19 full-width chars, is displayed fully, even on a fairly low DPI display.

![screenshot_20190119_133144](https://user-images.githubusercontent.com/36130650/51424109-796f9400-1bef-11e9-89c0-d5aa81995401.png)
