### PR TITLE
Improve grenades

### DIFF
--- a/mods/pvp/shooter/grenade.lua
+++ b/mods/pvp/shooter/grenade.lua
@@ -21,7 +21,7 @@ minetest.register_entity("shooter:grenade_entity", {
 	end,
 	on_step = function(self, dtime)
 		self.timer = self.timer + dtime
-		if self.timer > 0.2 then
+		if self.timer > 0.1 then
 			local pos = self.object:getpos()
 			local above = {x=pos.x, y=pos.y + 1, z=pos.z}
 			if minetest.get_node(pos).name ~= "air" then
@@ -41,26 +41,25 @@ minetest.register_tool("shooter:grenade", {
 	inventory_image = "shooter_hand_grenade.png",
 	on_use = function(itemstack, user, pointed_thing)
 		if not minetest.settings:get_bool("creative_mode") then
-			itemstack = ""
+			itemstack:take_item()
 		end
-		-- clarification for future readers: grenade can be used only if player points at nothing (line 47)
 		if pointed_thing.type ~= "nothing" then
 			local pointed = minetest.get_pointed_thing_position(pointed_thing)
-			if vector.distance(user:getpos(), pointed) < 10 then
+			if vector.distance(user:get_pos(), pointed) < 10 then
 				shooter:blast(pointed, 2, 25, 5)
 				return
 			end
 		end
-		local pos = user:getpos()
+		local pos = user:get_pos()
 		local dir = user:get_look_dir()
 		local yaw = user:get_look_yaw()
 		if pos and dir then
 			pos.y = pos.y + 1.5
 			local obj = minetest.add_entity(pos, "shooter:grenade_entity")
 			if obj then
-				obj:setvelocity({x=dir.x * 15, y=dir.y * 15, z=dir.z * 15})
-				obj:setacceleration({x=dir.x * -3, y=-10, z=dir.z * -3})
-				obj:setyaw(yaw + math.pi)
+				obj:set_velocity({x = dir.x * 20, y = dir.y * 20, z = dir.z * 20})
+				obj:set_acceleration({x=dir.x * -3, y=-10, z=dir.z * -3})
+				obj:set_yaw(yaw + math.pi)
 				local ent = obj:get_luaentity()
 				if ent then
 					ent.player = ent.player or user

--- a/mods/pvp/shooter/shooter.lua
+++ b/mods/pvp/shooter/shooter.lua
@@ -383,6 +383,8 @@ function shooter:blast(pos, radius, fleshy, distance, user)
 			minetest.set_node(pos, {name="tnt:boom"})
 		end
 	end
+
+	-- Explosion particles
 	if SHOOTER_ENABLE_PARTICLE_FX == true then
 		minetest.add_particlespawner(50, 0.1,
 			p1, p2, {x=-0, y=-0, z=-0}, {x=0, y=0, z=0},
@@ -390,6 +392,8 @@ function shooter:blast(pos, radius, fleshy, distance, user)
 			0.1, 1, 8, 15, false, "tnt_smoke.png"
 		)
 	end
+
+	-- Damage to objects within range
 	local objects = minetest.get_objects_inside_radius(pos, distance)
 	for _,obj in ipairs(objects) do
 		if (obj:is_player() and SHOOTER_ALLOW_PLAYERS == true) or
@@ -397,7 +401,7 @@ function shooter:blast(pos, radius, fleshy, distance, user)
 				obj:get_luaentity().name ~= "__builtin:item") then
 			local obj_pos = obj:getpos()
 			local dist = vector.distance(obj_pos, pos)
-			local damage = (fleshy * 0.5 ^ dist) * 3
+			local damage = fleshy * (0.707106 ^ dist) * 3
 			if dist ~= 0 then
 				obj_pos.y = obj_pos.y + 1.7
 				blast_pos = {x=pos.x, y=pos.y + 4, z=pos.z}
@@ -410,6 +414,8 @@ function shooter:blast(pos, radius, fleshy, distance, user)
 			end
 		end
 	end
+
+	-- Node blasting using LVM
 	if SHOOTER_ALLOW_NODES and SHOOTER_ENABLE_BLASTING then
 		local pr = PseudoRandom(os.time())
 		local vm = VoxelManip()


### PR DESCRIPTION
- Reduce collision-checking interval. Fixes grenades occasionally passing right through nodes without exploding.
- Increase initial velocity of grenade entity. Players can enjoy improved accuracy and larger range due to the increased initial velocity.
- Make grenade blast damage scaling more realistic. See table below for comparison.
- ~~Allow stacking upto 10 grenades~~

#### Blast damage scaling comparison

Current formula: `fleshy * 0.5 ^ dist * 3`
Proposed formula: `fleshy * 0.5 / dist * 3`

Player's distance from grenade in `m` | Damage (current formula) in `HP` | Damage (proposed formula) in `HP`
--- | --- | ---
0.1 | 69.97 | 375
0.5 | 53.03 | 75
1 | 37.5 | 37.5
2 | 18.75 | 18.75
3 | 9.375 | 12.5
4 | 4.69 | 9.375
5 | 2.34 | 7.5

Notice how the damage is extremely low and unrealistic as the distance from the grenade increases as per the current formula. The new formula makes damage a little more realistic and consistent, even at higher distances.