### PR TITLE
Fix missing indestructible stairs and wool

### DIFF
--- a/mods/ctf/ctf_map/depends.txt
+++ b/mods/ctf/ctf_map/depends.txt
@@ -1,4 +1,6 @@
 default
+stairs?
+wool?
 ctf_team_base?
 ctf?
 ctf_match?


### PR DESCRIPTION
Trivial PR - adds `stairs` and `wool` as optional dependencies of `ctf_map` to fix occasionally missing indestructible stairs and wool. Tested; please merge as soon as possible.