### PR TITLE
Reduce Spikes Cost from 5 Iron Ingots to 2.

### DIFF
--- a/mods/ctf/ctf_crafting/init.lua
+++ b/mods/ctf/ctf_crafting/init.lua
@@ -205,7 +205,7 @@ crafting.register_recipe({
 crafting.register_recipe({
 	type   = "inv",
 	output = "ctf_traps:spike 1",
-	items  = { "default:steel_ingot 5" },
+	items  = { "default:steel_ingot 2" },
 	always_known = true,
 	level  = 1,
 })


### PR DESCRIPTION
Seems more appropriate to me.

A steel sword also only costs 2 iron ingots and will usually deal more damage than a single spike node, so I don't think this is too cheap.