### PR TITLE
Tweak medkits settings - Part 2

### DIFF
--- a/mods/ctf/ctf_treasure/init.lua
+++ b/mods/ctf/ctf_treasure/init.lua
@@ -23,5 +23,5 @@ function ctf_treasure.register_default_treasures()
 	treasurer.register_treasure("shooter:arrow_white",0.5,2,{2,18})
 
 	treasurer.register_treasure("ctf_bandages:bandage",0.3,5,{1,6})
-	treasurer.register_treasure("medkits:medkit",0.8,5,{2,4})
+	treasurer.register_treasure("medkits:medkit",0.8,5,2)
 end

--- a/mods/other/sprint/init.lua
+++ b/mods/other/sprint/init.lua
@@ -47,7 +47,7 @@ minetest.register_globalstep(function(dtime)
 			-- ##1## replace info.sprintRequested with info.sprinting
 			if sprintRequested ~= info.sprintRequested then
 				if sprintRequested and info.stamina > MIN_SPRINT
-						and not is_healing(player:get_player_name()) then
+						and not medkits.is_healing(player:get_player_name()) then
 					setSprinting(player, info, true)
 				elseif not sprintRequested then
 					setSprinting(player, info, false)


### PR DESCRIPTION
- Tweak medkits: Increase `regen_interval` to 0.5
  - This is because medkits are currently way too OP, since a player can now heal upto 20 HP within just a couple of seconds.
- Optimize medkits: Remove unwanted variable(s), since the HP target is now the same as `regen_max`.
- Update maps sub-module to the [latest commit](4665c084c6f9ea317e122898585c110e9abd3c3c)

DON'T SQUASH ME! `>:|`