### PR TITLE
Add ctf_markers mod

### DIFF
--- a/mods/ctf/ctf_marker/init.lua
+++ b/mods/ctf/ctf_marker/init.lua
@@ -1,0 +1,128 @@
+-- Locally cache list of team members when adding
+-- marker, because the members in the team needn't
+-- be the same within an extended duration of time
+local teams = {}
+local visibility_time = 10
+
+-- Convenience function that returns passed
+-- string enclosed by color escape codes
+local function msg(str)
+	if not str then
+		return
+	end
+	return minetest.colorize("#ABCDEF", str)
+end
+
+-- Remove waypoint element for valid players in team tname
+local function remove_marker(tname)
+	for name, hud in pairs(teams[tname].players) do
+		local player = minetest.get_player_by_name(name)
+		if player then
+			player:hud_remove(hud)
+		end
+	end
+	teams[tname] = nil
+end
+
+-- Add waypoint element to all players in the same team as name
+local function add_marker(name, tname, pos, str)
+	local player = minetest.get_player_by_name(name)
+	if not player then
+		return
+	end
+
+	local team = ctf.team(tname)
+
+	teams[tname] = {
+		players = {},
+		time = 0
+	}
+	for pname, _ in pairs(team.players) do
+		local tplayer = minetest.get_player_by_name(pname)
+		if tplayer then
+			teams[tname].players[pname] = tplayer:hud_add({
+				hud_elem_type = "waypoint",
+				name      = str,
+				number    = ctf.flag_colors[team.data.color],
+				world_pos = pos
+			})
+		end
+		minetest.chat_send_player(pname,
+				msg("Player " .. name .. " placed a marker!"))
+	end
+end
+
+minetest.register_globalstep(function(dtime)
+	for tname, team in pairs(teams) do
+		-- Increment time of team marker
+		local time = team.time + dtime
+		teams[tname].time = time
+
+		-- If time > visibility_time, destroy team marker
+		if time >= visibility_time then
+			remove_marker(tname)
+		end
+	end
+end)
+
+minetest.register_chatcommand("m", {
+	param = "[Optional description]",
+	description = "Allows players to share the location of where " ..
+	              "they're looking at with their team-mates.",
+	privs = { interact = true },
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return
+		end
+
+		-- Calculate marker pos
+		local dir = player:get_look_dir()
+		local p1 = vector.add(player:get_pos(),
+				   { x = 0, y = player:get_properties().eye_height, z = 0})
+		p1 = vector.add(p1, dir)
+		local p2 = vector.add(p1, vector.multiply(dir, 500))
+		local pointed = minetest.raycast(p1, p2, true, true):next()
+
+		if not pointed then
+			minetest.chat_send_player(name, msg("Pointed thing out of range!"))
+			return
+		end
+
+		local tname = ctf.player(name).team
+
+		-- Handle waypoint string
+		local str = (param and param:trim() ~= "") and param or name .. "'s marker"
+		if pointed.type == "object" then
+			local concat
+			local obj = pointed.ref
+			if obj:is_player() then
+				concat = obj:get_player_name()
+			else
+				local entity = obj:get_luaentity()
+				-- If obj is item entity, append item description and count to str.
+				-- Fallback to itemstring if description doesn't exist
+				if entity.name == "__builtin:item" then
+					local stack = ItemStack(entity.itemstring)
+					local itemdef = minetest.registered_items[stack:get_name()]
+					concat = itemdef.description or entity.itemstring
+					concat = concat .. " " .. stack:get_count()
+				else
+					-- Pointed thing is a trivial entity, abort
+					minetest.chat_send_player(name,
+							msg("Invalid marker position. Please try again."))
+					return
+				end
+			end
+			str = concat and str .. " <" .. concat .. ">"
+		end
+		str = "[" .. str .. "]"
+
+		-- Remove existing marker if it exists
+		if teams[tname] then
+			remove_marker(tname)
+		end
+
+		add_marker(name, tname, minetest.get_pointed_thing_position(pointed), str)
+	end
+})

--- a/mods/ctf/ctf_marker/mod.conf
+++ b/mods/ctf/ctf_marker/mod.conf
@@ -1,0 +1,3 @@
+name = ctf_marker
+description = A chat-command allows team-mates to quickly know what a player is pointing at.
+depends = ctf

--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -49,7 +49,7 @@ function random_messages.read_messages()
 	random_messages.messages = {
 		"To talk to only your team, start your messages with /t. For example, /t Hello team!",
 		"Use medkits to gradually restore your health.",
-		"Moving or fighting while healing will interrupt the healing process.",
+		"Moving or fighting while using medkits will interrupt the healing process.",
 		"Steel swords do more damage than guns, but you need to be up close.",
 		"Gain more score by killing more than you die, or by capturing the flag.",
 		"You gain more score the better the opponent you defeat.",
@@ -68,7 +68,8 @@ function random_messages.read_messages()
 		"Help your team claim victory by storing extra weapons in the team chest, and never taking more than you need.",
 		"Excessive spawn-killing is a direct violation of the rules - appropriate punishments will be given.",
 		"Use /r to check your score and rank, and /rankings to see the league tables.",
-		"Use bandages on team-mates to heal them by 3-4 HP if their health is below 15 HP."
+		"Use bandages on team-mates to heal them by 3-4 HP if their health is below 15 HP.",
+		"Use /m to add a team marker at pointed location, that's visible only to team-mates."
 	}
 end
 


### PR DESCRIPTION
This PR adds a new mod `ctf_marker`, that allows players to share their pointed location with their team-mates using a chat-command (`/m [description]`).

- Each marker is visible for 30s.
- Each team can only have one active marker at any given time.
- If a new marker is created while an old marker exists, the old marker is deleted before the new marker is shown.
- Nodes (including liquids), players, and item entities are valid marker targets.
- While creating a marker, players can pass optional descriptions for the markers, and if a string isn't provided, the following description is used for the waypoint instead: `[<name>'s marker]`.
- Waypoint string goes through some special handling, based to marker target type:
  - If target is a player, the player's name is automatically appended to the string.
  - If target is an item entity, the item description + item count is appended to the string.

**NOTE:** If target is a player, the marker's pos will correspond to position of player at the time of marking, and the marker won't move with the player.

#### TODO:

- [x] Player pos is taken as marker pos at present. Use Raycast to mark the first thing in line-of-sight instead.
- [x] Marker doesn't disappear once its time's up. FIX IT.
- [x] Existing marker isn't removed when adding two markers. FIX IT.

Tested - everything works. Video demonstration: https://youtu.be/_fhZ1q1_cxo