### PR TITLE
Fix normal -> unbreakable bug

### DIFF
--- a/mods/ctf/ctf_map/nodes.lua
+++ b/mods/ctf/ctf_map/nodes.lua
@@ -752,9 +752,11 @@ minetest.register_node("ctf_map:killnode", {
 -- Re-register all nodes from stairs and wool
 for name, nodedef in pairs(minetest.registered_nodes) do
 	if name:find("stairs") then
+		nodedef = table.copy(nodedef)
 		nodedef.groups = {immortal = 1}
 		minetest.register_node("ctf_map:" .. name:split(":")[2], nodedef)
 	elseif name:find("wool") then
+		nodedef = table.copy(nodedef)
 		nodedef.groups = {immortal = 1}
 		minetest.register_node("ctf_map:" .. name:split(":")[2], nodedef)
 	end


### PR DESCRIPTION
There seems to be a critical bug regarding slabs/stairs and wool: When a player digs a normal slab/stair/wool and places it, it turns into a unbreakable one after placing.

This fix is tested, seems to work.

@rubenwardy, @ClobberXD Please review and merge as soon as possible.