### PR TITLE
Increase marker visibility time to 30 seconds

### DIFF
--- a/mods/ctf/ctf_marker/init.lua
+++ b/mods/ctf/ctf_marker/init.lua
@@ -2,7 +2,7 @@
 -- marker, because the members in the team needn't
 -- be the same within an extended duration of time
 local teams = {}
-local visibility_time = 10
+local visibility_time = 30
 
 -- Convenience function that returns passed
 -- string enclosed by color escape codes


### PR DESCRIPTION
Seems like this was intended anyway:
Quote from https://github.com/MT-CTF/capturetheflag/pull/360#issue-258746976:

> Each marker is visible for 30s.

The current time seems way too short.