### PR TITLE
Fix indestructible snow and ice not being slippery

### DIFF
--- a/mods/ctf/ctf_map/nodes.lua
+++ b/mods/ctf/ctf_map/nodes.lua
@@ -344,7 +344,7 @@ do
 				{-0.5, -0.5, -0.5, 0.5, -0.25, 0.5},
 			},
 		},
-		groups = {immortal = 1},
+		groups = {immortal = 1, slippery = 2},
 		sounds = default.node_sound_dirt_defaults({
 			footstep = {name = "default_snow_footstep", gain = 0.15},
 			dug = {name = "default_snow_footstep", gain = 0.2},
@@ -355,7 +355,7 @@ do
 	minetest.register_node("ctf_map:snowblock", {
 		description = "Indestructible Snow Block",
 		tiles = {"default_snow.png"},
-		groups = {immortal = 1},
+		groups = {immortal = 1, slippery = 2},
 		sounds = default.node_sound_dirt_defaults({
 			footstep = {name = "default_snow_footstep", gain = 0.15},
 			dug = {name = "default_snow_footstep", gain = 0.2},
@@ -368,7 +368,7 @@ do
 		tiles = {"default_ice.png"},
 		is_ground_content = false,
 		paramtype = "light",
-		groups = {immortal = 1},
+		groups = {immortal = 1, slippery = 4},
 		sounds = default.node_sound_glass_defaults(),
 	})
 


### PR DESCRIPTION
Adds missing `slippery` group to `ctf_map:snow`, `ctf_map:snowblock`, and `ctf_map:ice`.