### PR TITLE
Add maps catalog

### DIFF
--- a/mods/ctf/ctf_map/init.lua
+++ b/mods/ctf/ctf_map/init.lua
@@ -11,18 +11,19 @@ function ctf_map.can_cross(player)
 	return false
 end
 
-dofile(minetest.get_modpath("ctf_map") .. "/nodes.lua")
-dofile(minetest.get_modpath("ctf_map") .. "/emerge.lua")
-dofile(minetest.get_modpath("ctf_map") .. "/barrier.lua")
-dofile(minetest.get_modpath("ctf_map") .. "/base.lua")
+local modpath = minetest.get_modpath("ctf_map")
+dofile(modpath .. "/nodes.lua")
+dofile(modpath .. "/emerge.lua")
+dofile(modpath .. "/barrier.lua")
+dofile(modpath .. "/base.lua")
 
 if minetest.get_modpath("ctf") then
-	dofile(minetest.get_modpath("ctf_map") .. "/chest.lua")
-	dofile(minetest.get_modpath("ctf_map") .. "/schem_map.lua")
-	dofile(minetest.get_modpath("ctf_map") .. "/give_initial_stuff.lua")
+	dofile(modpath .. "/chest.lua")
+	dofile(modpath .. "/give_initial_stuff.lua")
+	dofile(modpath .. "/schem_map.lua")
+	dofile(modpath .. "/maps_catalog.lua")
 
-	assert(ctf_match)
 	ctf_match.register_on_build_time_end(ctf_map.remove_middle_barrier)
 else
-	dofile(minetest.get_modpath("ctf_map") .. "/map_maker.lua")
+	dofile(modpath .. "/map_maker.lua")
 end

--- a/mods/ctf/ctf_map/maps_catalog.lua
+++ b/mods/ctf/ctf_map/maps_catalog.lua
@@ -1,0 +1,113 @@
+-- Maps Catalog Formspec
+
+local indices = {}
+
+local function show_catalog(name, idx)
+	indices[name] = idx
+
+	-- Select map to be displayed
+	local map = ctf_map.available_maps[idx]
+
+	local fs = "size[10,8]"
+
+	fs = fs .. "container[0,0]"
+	fs = fs .. "box[0,0;9.8,1;#111]"
+	if idx > 1 then
+		fs = fs .. "button[0.5,0.1;1,1;btn_prev;<---]"
+	end
+	if idx < #ctf_map.available_maps then
+		fs = fs .. "button[8.5,0.1;1,1;btn_next;--->]"
+	end
+
+	-- Map name and author
+	fs = fs .. "label[3,0;" .. minetest.formspec_escape(map.name) .. "]"
+	fs = fs .. "label[5,0.5;" .. "(by " .. minetest.formspec_escape(map.author) .. ")]"
+	fs = fs .. "container_end[]"
+
+	-- List of maps
+	fs = fs .. "textlist[0,1.2;3.5,6.8;maps_list;"
+	for i, v in pairs(ctf_map.available_maps) do
+		local mname = v.name
+
+		-- If entry corresponds to selected map, highlight in yellow
+		if i == idx then
+			mname = "#FFFF00" .. mname
+		end
+
+		fs = fs .. mname
+		if i < #ctf_map.available_maps then
+			fs = fs .. ","
+		end
+	end
+	fs = fs .. ";" .. idx .. ";false]"
+
+	-- Display screenshot if present, and move other elements down
+	local y = 1
+	if map.screenshot then
+		fs = fs .. "image[4,1.5;6.5,3.5;" .. map.screenshot .. "]"
+		y = y + 4
+	end
+
+	-- Other fields
+	fs = fs .. "container[3.5," .. y + 0.5 .. "]"
+	fs = fs .. "label[0.5,0;HINT: " ..
+			minetest.formspec_escape(map.hint or "---") .. "]"
+	fs = fs .. "label[0.5,0.5;LICENSE: " ..
+			minetest.formspec_escape(map.license or "---") .. "]"
+	fs = fs .. "container_end[]"
+
+	minetest.show_formspec(name, "ctf_map:maps_catalog", fs)
+end
+
+minetest.register_on_player_receive_fields(function(player, formname, fields)
+	if not player or formname ~= "ctf_map:maps_catalog" then
+		return
+	end
+
+	local name = player:get_player_name()
+
+	if fields.btn_prev then
+		show_catalog(name, indices[name] - 1)
+	elseif fields.btn_next then
+		show_catalog(name, indices[name] + 1)
+	end
+
+	if fields.maps_list then
+		local evt = minetest.explode_textlist_event(fields.maps_list)
+		if evt.type ~= "INV" then
+			show_catalog(name, evt.index)
+		end
+	end
+end)
+
+minetest.register_chatcommand("maps", {
+	privs = {interact = true},
+	func = function(name, param)
+		if not minetest.get_player_by_name(name) then
+			return false, "You must be online to view the maps catalog!"
+		end
+
+		-- Set param to nil if it's empty
+		if param and param:trim() == "" then
+			param = nil
+		end
+
+		local idx
+
+		-- If arg. supplied, set idx to index of the matching map name
+		-- or path. Else, set to indices[name] or index of current map
+		if param then
+			for i, map in pairs(ctf_map.available_maps) do
+				if map.name:find(param) or map.path:find(param) then
+					idx = i
+					break
+				end
+			end
+		else
+			idx = indices[name] or ctf_map.map.idx
+		end
+
+		show_catalog(name, idx or 1)
+		return true
+	end
+})


### PR DESCRIPTION
This PR allows maps to have a description, a valid viewable license field, etc. which can be seen by players using the `/maps` chat-command. This is required for maps adapted from existing Minetest maps or worlds, like @JostP / -sniper-'s [adaptations of Karsthafen](https://github.com/MT-CTF/maps/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+author%3AJostP+Karsthafen) otherwise the original author(s) can't be attributed (adding attributions to `hint` or `author` fields is a strict no-no as that'll end up flooding the chat).

### Implementation details

- New chat-command `/maps`. Shows the details of the current map in the maps catalog, 
  - This chat-command supports specifying an optional string, which selects the map whose name it matches, instead of the current map. e.g. `/maps caverns`.
- All maps' metas are loaded at startup, instead of loading the meta only for the selected map. This allows the maps catalog to access the all the fields to be displayed.
- There are `<---` and `--->` buttons to view the previous and next map respectively, and there's also a list of maps to allow viewing a specific map directly.
- Maps catalog supports screenshots out of the box, and checks for the `screenshot` map meta field. I plan on adding screenshot support in the directory structures in #352.
  - There's a catch. Since media can only be sent at load-time, reloading maps at runtime using `/reload_maps` will not send the screenshots of new maps to the client. Fixing this is out of the scope of this PR.
  - I'm also not sure how the screenshots can be automatically sent to the client without having to manually move them to `mods/ctf_map/textures/`. Note that the screenshots aren't just moved from one directory to another, but from one repo to another)

### Screenshot

![screenshot_20190426_152316](https://user-images.githubusercontent.com/36130650/56800241-32212100-6838-11e9-8384-37d99db9430c.png)

****

Extensively tested, everything works.