### PR TITLE
Exclude map's initial_stuff from list of treasures

### DIFF
--- a/mods/ctf/ctf_treasure/init.lua
+++ b/mods/ctf/ctf_treasure/init.lua
@@ -1,27 +1,29 @@
 ctf_treasure = {}
 
-function ctf_treasure.register_default_treasures()
-	treasurer.register_treasure("default:ladder",0.3,5,{1,20})
-	treasurer.register_treasure("default:torch",0.3,5,{1,20})
-	treasurer.register_treasure("default:cobble",0.4,5,{45,99})
-	treasurer.register_treasure("default:wood",0.3,5,{30,60})
-	treasurer.register_treasure("doors:door_steel",0.3,5,{1,3})
+function ctf_treasure.get_default_treasures()
+	return {
+		{"default:ladder",0.3,5,{1,20}},
+		{"default:torch",0.3,5,{1,20}},
+		{"default:cobble",0.4,5,{45,99}},
+		{"default:wood",0.3,5,{30,60}},
+		{"doors:door_steel",0.3,5,{1,3}},
 
-	treasurer.register_treasure("default:pick_steel",0.5,5,{1,10})
-	treasurer.register_treasure("default:sword_stone",0.6,5,{1,10})
-	treasurer.register_treasure("default:sword_steel",0.4,5,{1,4})
-	treasurer.register_treasure("default:shovel_stone",0.6,5,{1,10})
-	treasurer.register_treasure("default:shovel_steel",0.3,5,{1,10})
+		{"default:pick_steel",0.5,5,{1,10}},
+		{"default:sword_stone",0.6,5,{1,10}},
+		{"default:sword_steel",0.4,5,{1,4}},
+		{"default:shovel_stone",0.6,5,{1,10}},
+		{"default:shovel_steel",0.3,5,{1,10}},
 
-	treasurer.register_treasure("shooter:crossbow",0.5,2,{1,5})
-	treasurer.register_treasure("shooter:pistol",0.4,2,{1,5})
-	treasurer.register_treasure("shooter:rifle",0.1,2,{1,2})
-	treasurer.register_treasure("shooter:shotgun",0.04,2,1)
-	treasurer.register_treasure("shooter:grenade",0.08,2,1)
-	treasurer.register_treasure("shooter:machine_gun",0.02,2,1)
-	treasurer.register_treasure("shooter:ammo",0.3,2,{1,10})
-	treasurer.register_treasure("shooter:arrow_white",0.5,2,{2,18})
+		{"shooter:crossbow",0.5,2,{1,5}},
+		{"shooter:pistol",0.4,2,{1,5}},
+		{"shooter:rifle",0.1,2,{1,2}},
+		{"shooter:shotgun",0.04,2,1},
+		{"shooter:grenade",0.08,2,1},
+		{"shooter:machine_gun",0.02,2,1},
+		{"shooter:ammo",0.3,2,{1,10}},
+		{"shooter:arrow_white",0.5,2,{2,18}},
 
-	treasurer.register_treasure("ctf_bandages:bandage",0.3,5,{1,6})
-	treasurer.register_treasure("medkits:medkit",0.8,5,2)
+		{"ctf_bandages:bandage",0.3,5,{1,6}},
+		{"medkits:medkit",0.8,5,2}
+	}
 end


### PR DESCRIPTION
Treasures that are already a part of map's `initial_stuff` aren't registered.

![Screenshot from 2019-03-21 13-11-15](https://user-images.githubusercontent.com/36130650/54739108-da5e1d00-4bdc-11e9-91c9-0c742dc4baba.png)

(Note: Coloured chat output was just for testing, and has been replaced by calls to `minetest.log` in the PR)

Tested. Works.