### PR TITLE
Slow down players on flag pickup to 95% of normal speed

### DIFF
--- a/mods/ctf/ctf_match/matches.lua
+++ b/mods/ctf/ctf_match/matches.lua
@@ -82,10 +82,20 @@ function ctf_match.create_teams()
 	error("Error! Unimplemented")
 end
 
+ctf_flag.register_on_pick_up(function(name)
+	physics.set(name, "ctf_match:flag_mult", { speed = 0.95 })
+end)
+
+ctf_flag.register_on_drop(function(name)
+	physics.remove(name, "ctf_match:flag_mult")
+end)
+
 ctf_flag.register_on_capture(function(attname, flag)
 	if not ctf.setting("match.destroy_team") then
 		return
 	end
+
+	physics.remove(attname, "ctf_match:flag_mult")
 
 	local fl_team = ctf.team(flag.team)
 	if fl_team and #fl_team.flags == 0 then

--- a/mods/ctf/ctf_match/mod.conf
+++ b/mods/ctf/ctf_match/mod.conf
@@ -1,3 +1,3 @@
 name = ctf_match
-depends = ctf, ctf_flag, ctf_inventory, ctf_alloc, vote, hudkit
+depends = ctf, ctf_flag, ctf_inventory, ctf_alloc, vote, hudkit, physics
 optional_depends = irc


### PR DESCRIPTION
PR also takes other ways of losing flag into consideration while restoring original speed, like deaths and flag timeouts.

Semi-trivial. Tested - works.