### PR TITLE
README: Remove static list of mods, link to mods/

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,25 +33,4 @@ Textures: CC-BY-SA 3.0
 
 ### Mods
 
-* [afkkick](https://forum.minetest.net/viewtopic.php?t=10919) by GunshipPenguin (CC0 1.0)
-* [ctf_pvp_engine](https://forum.minetest.net/viewtopic.php?f=15&t=6947) by rubenwardy (LGPLv2.1+)
-* [chatplus](https://forum.minetest.net/viewtopic.php?id=6273) by rubenwardy (LGPLv2.1+)
-* [dropondie](https://forum.minetest.net/viewtopic.php?id=7835) by minermoder27 (Apache 2.0)
-* [email](https://forum.minetest.net/viewtopic.php?t=13754) by rubenwardy (MIT)
-* [gauges](https://forum.minetest.net/viewtopic.php?t=10250) by Calinou (CC0)
-* [random_messages](https://forum.minetest.net/viewtopic.php?t=6306) by arsdragonfly (CC0)
-* [report](https://forum.minetest.net/viewtopic.php?t=13752) by rubenwardy (CC0)
-* [sprint](https://forum.minetest.net/viewtopic.php?t=9650) by GunshipPenguin, rewritten and optimised (CC0 1.0)
-* [treasurer](https://forum.minetest.net/viewtopic.php?t=7292) by Wuzzy (WTFPL)
-* [tsm_chests](https://forum.minetest.net/viewtopic.php?t=7292) by Wuzzy (WTFPL)
-* [vote](https://forum.minetest.net/viewtopic.php?t=12829) by rubenwardy (MIT)
-* [wield3d](https://forum.minetest.net/viewtopic.php?t=6407) by stu (WTFPL)
-* Minetest Game mods: default, doors, furnace, game_commands, player_api, sfinv, stairs, wool.
-  Fun fact: sfinv was made for this subgame, and then merged into MTG.
-
-**Custom Mods:**
-
-* hpregen by rubenwardy (LGPLv2.1+)
-* ctf_* by rubenwardy (LGPLv2.1+)
-* no_minimap by rubenwardy (LGPLv2.1+)
-* respawn_immunity by rubenwardy (LGPLv2.1+)
+Check out [mods/](mods/) to see all the installed mods and their respective licenses.


### PR DESCRIPTION
It's hard to maintain a static list of mods when the list just keeps growing. The list is replaced by a sentence that encourages readers to go to `mods/` and check out the mods themselves. Hopefully, it doesn't sound too rude. :)