### PR TITLE
physics: Remove asserts and physics.change

### DIFF
--- a/mods/other/physics/init.lua
+++ b/mods/other/physics/init.lua
@@ -29,19 +29,19 @@ local function update(name)
 end
 
 function physics.set(pname, name, modifiers)
-	assert(players[pname] and not players[pname][name])
+	if not players[pname] then
+		return
+	end
+
 	players[pname][name] = modifiers
 	update(pname)
 end
 
-function physics.change(pname, name, modifier)
-	assert(players[pname] and players[pname][name])
-	players[pname][name] = modifier
-	update(pname)
-end
-
 function physics.remove(pname, name)
-	assert(players[pname] and players[pname][name])
+	if not players[pname] then
+		return
+	end
+
 	players[pname][name] = nil
 	update(pname)
 end


### PR DESCRIPTION
Without its assert, `physics.set` does the exact same thing `physics.change` would do.

`physics.remove` itself is just a convenience function, so to say - one could just call `physics.set(pname, "modifier_to_be_removed")` and the modifier will be removed.