### PR TITLE
ctf_map: Fix per-map treasures registering at server startup

### DIFF
--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -130,56 +130,6 @@ local function load_map_meta(idx, path)
 		i = i + 1
 	end
 
-	-- Register per-map treasures, or the default set of treasures
-	-- if treasures field hasn't been defined in map meta
-	if ctf_treasure then
-		treasurer.treasures = {}
-		if treasures then
-			for _, item in pairs(treasures) do
-				item = item:split(",")
-				-- treasurer.register_treasure(name, rarity, preciousness, count)
-				if #item == 4 then
-					treasurer.register_treasure(item[1],
-						tonumber(item[2]),
-						tonumber(item[3]),
-						tonumber(item[4]))
-				-- treasurer.register_treasure(name, rarity, preciousness, {min, max})
-				elseif #item == 5 then
-					treasurer.register_treasure(item[1],
-						tonumber(item[2]),
-						tonumber(item[3]),
-						{
-							tonumber(item[4]),
-							tonumber(item[5])
-						})
-				end
-			end
-		else
-			-- If treasure is a part of map's initial stuff, don't register it
-			local blacklist = map.initial_stuff or give_initial_stuff.get_stuff()
-			for _, def in pairs(ctf_treasure.get_default_treasures()) do
-				local is_valid = true
-				for _, b_item in pairs(blacklist) do
-					local b_stack = ItemStack(b_item)
-					local t_stack = ItemStack(def[1])
-					if b_stack:get_name() == t_stack:get_name() and
-							t_stack:get_count() == 1 then
-						is_valid = false
-						minetest.log("action",
-								"ctf_map: Omitting treasure - " .. def[1])
-						break
-					end
-				end
-
-				if is_valid then
-					minetest.log("info",
-							"ctf_map: Registering treasure - " .. def[1])
-					treasurer.register_treasure(def[1], def[2], def[3], def[4])
-				end
-			end
-		end
-	end
-
 	-- Read custom chest zones from config
 	i = 1
 	while meta:get("chests." .. i .. ".from") do
@@ -342,6 +292,57 @@ ctf_match.register_on_new_match(function()
 	ctf_map.map.idx = idx
 
 	map_str = "Map: " .. ctf_map.map.name .. " by " .. ctf_map.map.author
+
+	-- Register per-map treasures, or the default set of treasures
+	-- if treasures field hasn't been defined in map meta
+	if ctf_treasure then
+		treasurer.treasures = {}
+		if ctf_map.treasures then
+			for _, item in pairs(ctf_map.treasures) do
+				item = item:split(",")
+				-- treasurer.register_treasure(name, rarity, preciousness, count)
+				if #item == 4 then
+					treasurer.register_treasure(item[1],
+							tonumber(item[2]),
+							tonumber(item[3]),
+							tonumber(item[4]))
+				-- treasurer.register_treasure(name, rarity, preciousness, {min, max})
+				elseif #item == 5 then
+					treasurer.register_treasure(item[1],
+							tonumber(item[2]),
+							tonumber(item[3]),
+							{
+								tonumber(item[4]),
+								tonumber(item[5])
+							})
+				end
+			end
+		else
+			-- If treasure is a part of map's initial stuff, don't register it
+			local blacklist = ctf_map.map.initial_stuff or give_initial_stuff.get_stuff()
+			for _, def in pairs(ctf_treasure.get_default_treasures()) do
+				local is_valid = true
+				for _, b_item in pairs(blacklist) do
+					local b_stack = ItemStack(b_item)
+					local t_stack = ItemStack(def[1])
+					if b_stack:get_name() == t_stack:get_name() and
+							t_stack:get_count() == 1 then
+						is_valid = false
+						minetest.log("action",
+								"ctf_map: Omitting treasure - " .. def[1])
+						break
+					end
+				end
+
+				if is_valid then
+					minetest.log("info",
+							"ctf_map: Registering treasure - " .. def[1])
+					treasurer.register_treasure(def[1], def[2], def[3], def[4])
+				end
+			end
+		end
+	end
+
 	-- Place map
 	place_map(ctf_map.map)
 end)


### PR DESCRIPTION
Fixes regression introduced by abbd62ac, which calls `load_map_meta` for all maps right at server startup, instead of calling it per-map for every new match.

The treasure registration has been moved to the `register_on_new_match` callback, which is obviously invoked at the start of every new match.

Tested, works.

To test, checkout this branch, launch CTF, open a bunch of chests across the map, and notice that the shiny steel toys are back! :D