### PR TITLE
Fix recursive registration of ind. stairs and wool

### DIFF
--- a/mods/ctf/ctf_map/nodes.lua
+++ b/mods/ctf/ctf_map/nodes.lua
@@ -750,7 +750,8 @@ end
 
 -- Register indestructible variants of nodes from stairs and wool
 do
-	for name, nodedef in pairs(minetest.registered_nodes) do
+	local nodes = table.copy(minetest.registered_nodes)
+	for name, nodedef in pairs(nodes) do
 		if name:find("stairs") then
 			nodedef = table.copy(nodedef)
 			nodedef.groups = {immortal = 1}


### PR DESCRIPTION
Bug caused by

https://github.com/MT-CTF/capturetheflag/blob/03f368743eb54629c184bea298b048a30c08d4b2/mods/ctf/ctf_map/nodes.lua#L751-L766

The loop registers nodes, _while_ iterating through `minetest.registered_nodes`, resulting in an infinite loop of sorts. Here's a sample of the warnings:

```
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:brown -> ctf_map:wool_brown
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_dark_grey -> ctf_map:wool_wool_dark_grey
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_brown -> ctf_map:wool_wool_brown
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_magenta -> ctf_map:wool_wool_magenta
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_red -> ctf_map:wool_wool_red
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_violet -> ctf_map:wool_wool_violet
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_wool_violet -> ctf_map:wool_wool_wool_violet
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_wool_red -> ctf_map:wool_wool_wool_red
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_wool_brown -> ctf_map:wool_wool_wool_brown
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_wool_dark_grey -> ctf_map:wool_wool_wool_dark_grey
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_grey -> ctf_map:wool_wool_grey
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_wool_wool_dark_grey -> ctf_map:wool_wool_wool_wool_dark_grey
2019-07-05 06:28:22: WARNING[Main]: Not registering alias, item with same name is already defined: ctf_map:wool_black -> ctf_map:wool_wool_black
```

(_Seriously? `wool_wool_wool_red`?_)

This is fixed by making a local deep copy of the table and iterating over that instead. Tested, works.