### PR TITLE
Make kill weapon detection great again!

### DIFF
--- a/mods/ctf/ctf_events/init.lua
+++ b/mods/ctf/ctf_events/init.lua
@@ -120,20 +120,17 @@ function ctf_events.update_all()
 	end
 end
 
-ctf.register_on_killedplayer(function(victim, killer, stack)
+ctf.register_on_killedplayer(function(victim, killer, stack, tool_caps)
 	local sname = stack:get_name()
-	local tool_caps = stack:get_tool_capabilities()
 	local type = "sword"
-	if sname:sub(1, 8) == "shooter:" then
-		if sname == "shooter:grenade" then
+	if sname == "" then
+		if tool_caps.damage_groups.grenade then
 			type = "grenade"
-		else
-			type = "bullet"
 		end
+	elseif sname:sub(1, 8) == "shooter:" then
+		type = "bullet"
 	end
-	if tool_caps.damage_groups.grenade then
-		type = "grenade"
-	end
+
 	ctf_events.post("kill_" .. type, killer, victim)
 	ctf_events.update_all()
 end)


### PR DESCRIPTION
Sister-PR of MT-CTF/ctf_pvp_engine#38. See that PR for more details.

![screenshot_20190706_211326](https://user-images.githubusercontent.com/36130650/60758334-ca573580-a033-11e9-959a-2968f0c85014.png)

Grenade kills are detected properly, again. :point_up_2: 