### PR TITLE
Fix flag claimed right after creation

### DIFF
--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -351,7 +351,7 @@ function ctf_match.create_teams()
 	for key, value in pairs(ctf_map.map.teams) do
 		local name  = key
 		local color = value.color
-		local flag  = value.pos
+		local flag  = table.copy(value.pos)
 
 		if name and color and flag then
 			print(" - creating " .. key)


### PR DESCRIPTION
Regression introduced by abbd62ac:

- Since abbd62ac, all map metas are loaded at server startup.
- In `ctf_match.create_teams`, `map.teams.pos` is passed to `ctf_flag.add`.
- As tables are passed by reference, properties added to `ctf.team("team_name").flags[i]` are also added to ctf_map.map.teams.
- This means that the next time this table is passed to `ctf_flag.add`, this table would already contain the `claimed` property, that holds the name of the player who last claimed the flag at this pos, and the name of their team. e.g.

```lua
ctf_flag.add("name", {
	x = ,
	y = ,
	z = ,
	claimed = {		-- what the actual heck
		team = ,
		player =
	}
})
```

This is fixed by simply passing `map.teams.pos` to `ctf_flag.add` using `table.copy`.

****

Thanks to:
- @Thomas-S for repro steps.
- @LoneWolfHT for doing most of the debugging.

Tested; works. One-line change, but requires testing by others.

To test:

- Fire up CTF, and wait for the first match.
- `/set_next <name of current map>` (sets the next map to be the same map).
- Capture the enemy's flag.
- Observe that the flag isn't already claimed at the start of the next match.