### PR TITLE
Improve directory structure of maps

### DIFF
--- a/mods/ctf/ctf_map/map_maker.lua
+++ b/mods/ctf/ctf_map/map_maker.lua
@@ -371,7 +371,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		we_select(player_name)
 		show_progress_formspec(player_name, "Exporting...")
 
-		local path = minetest.get_worldpath() .. "/schems/"
+		local path = minetest.get_worldpath() .. "/schems/" .. config.mapname .. "/"
 		minetest.mkdir(path)
 
 		-- Reset mod_storage
@@ -384,7 +384,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		storage:set_string("barrier_r", "")
 
 		-- Write to .conf
-		local meta = Settings(path .. config.mapname .. ".conf")
+		local meta = Settings(path .. "map.conf")
 		meta:set("name", config.maptitle)
 		meta:set("author", config.mapauthor)
 		if config.mapinitial ~= "" then
@@ -410,7 +410,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		meta:write()
 
 		minetest.after(0.1, function()
-			local filepath = path .. config.mapname .. ".mts"
+			local filepath = path .. "map.mts"
 			if minetest.create_schematic(worldedit.pos1[player_name],
 					worldedit.pos2[player_name], worldedit.prob_list[player_name],
 					filepath) then

--- a/mods/ctf/ctf_map/maps_catalog.lua
+++ b/mods/ctf/ctf_map/maps_catalog.lua
@@ -45,8 +45,10 @@ local function show_catalog(name, idx)
 
 	-- Display screenshot if present, and move other elements down
 	local y = 1
-	if map.screenshot then
-		fs = fs .. "image[4,1.5;6.5,3.5;" .. map.screenshot .. "]"
+	if ctf_map.file_exists(map.dirname, "screenshot.png") then
+		-- Check for mapdir .. "/screenshot.png", but pass in the texture
+		-- name, which would've been renamed to mapdir .. ".png"
+		fs = fs .. "image[4,1.5;6.5,3.5;" .. map.dirname .. ".png" .. "]"
 		y = y + 3.5
 	end
 

--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -59,7 +59,7 @@ function ctf_map.get_idx_and_map(param)
 	param = param:lower():trim()
 	for i, map in pairs(ctf_map.available_maps) do
 		if map.name:lower():find(param, 1, true) or
-				map.path:lower():find(param, 1, true) then
+				map.dirname:lower():find(param, 1, true) then
 			return i, map
 		end
 	end
@@ -80,15 +80,12 @@ minetest.register_chatcommand("set_next", {
 	end,
 })
 
-local function load_map_meta(idx, path, filename)
-	minetest.log("info", "load_map_meta: Loading map meta from \"" .. path .. filename .. "\"")
-	local conf_path = ctf_map.mapdir .. path .. filename .. ".conf"
-	local offset    = vector.new(600 * idx, 0, 0)
-	local meta      = Settings(conf_path)
-
+local function load_map_meta(idx, dirname, meta)
 	if not meta:get("r") then
-		error("Map was not properly configured " .. conf_path)
+		error("Map was not properly configured: " .. dirname .. "/map.conf")
 	end
+
+	local offset = vector.new(600 * idx, 0, 0)
 
 	local initial_stuff = meta:get("initial_stuff")
 	local treasures = meta:get("treasures")
@@ -96,24 +93,21 @@ local function load_map_meta(idx, path, filename)
 	local time_speed = meta:get("time_speed")
 
 	local map = {
+		dirname       = dirname,
+		r             = tonumber(meta:get("r")),
+		h             = tonumber(meta:get("h")),
 		name          = meta:get("name"),
-		path          = path,
-		filename      = filename,
 		author        = meta:get("author"),
 		hint          = meta:get("hint"),
 		rotation      = meta:get("rotation"),
-		screenshot    = meta:get("screenshot"),
-		skybox        = ctf_map.skybox_exists(path, filename),
 		license       = meta:get("license"),
 		others        = meta:get("others"),
 		base_node     = meta:get("base_node"),
-		schematic     = path .. filename .. ".mts",
 		initial_stuff = initial_stuff and initial_stuff:split(","),
 		treasures     = treasures and treasures:split(";"),
 		start_time    = start_time and tonumber(start_time),
 		time_speed    = time_speed and tonumber(time_speed),
-		r             = tonumber(meta:get("r")),
-		h             = tonumber(meta:get("h")),
+		skybox        = ctf_map.skybox_exists(dirname),
 		offset        = offset,
 		teams         = {},
 		chests        = {}
@@ -141,7 +135,7 @@ local function load_map_meta(idx, path, filename)
 
 	-- Read custom chest zones from config
 	i = 1
-	minetest.log("info", "Parsing chest zones of " .. map.name .. "...")
+	minetest.log("verbose", "Parsing chest zones of " .. map.name .. "...")
 	while meta:get("chests." .. i .. ".from") do
 		local from  = minetest.string_to_pos(meta:get("chests." .. i .. ".from"))
 		local to    = minetest.string_to_pos(meta:get("chests." .. i .. ".to"))
@@ -153,8 +147,6 @@ local function load_map_meta(idx, path, filename)
 			to   = vector.add(offset, to),
 			n    = tonumber(meta:get("chests." .. i .. ".n") or "23"),
 		}
-
-		minetest.log("info", dump(map.chests[i]))
 
 		i = i + 1
 	end
@@ -189,46 +181,22 @@ local function load_map_meta(idx, path, filename)
 end
 
 local function load_maps()
-	local files_hash = {}
-
-	local dirs = minetest.get_dir_list(ctf_map.mapdir, true)
-	table.insert(dirs, ".")
-	for _, dir in pairs(dirs) do
-		if dir ~= ".git" then
-			local files = minetest.get_dir_list(ctf_map.mapdir .. dir, false)
-			for i = 1, #files do
-				local parts = files[i]:split(".")
-				local filename = parts[1]
-				local extension = parts[2]
-				if extension == "mts" then
-					files_hash[#files_hash + 1] = {
-						subdir   = dir .. "/",
-						filename = filename
-					}
-				else
-					if extension ~= "conf" and extension ~= "md" and extension ~= "png"
-							and files[i] ~= ".git" then
-						error("Map extension is not '.mts': " .. files[i])
-					end
-				end
-			end
-		end
-	end
-
 	local idx = 1
 	ctf_map.available_maps = {}
-	for i, path in pairs(files_hash) do
-		local conf = Settings(ctf_map.mapdir .. "/" ..
-			path.subdir .. path.filename .. ".conf")
-		local val = minetest.settings:get("ctf.maps." ..
-			string.gsub(path.subdir .. path.filename, "%./", ""):gsub("/", "."))
-		if not conf:get_bool("disabled", false) and val ~= "false" then
-			local map = load_map_meta(idx, path.subdir, path.filename)
-			table.insert(ctf_map.available_maps, map)
+	for _, dirname in pairs(minetest.get_dir_list(ctf_map.mapdir, true)) do
+		if dirname ~= ".git" then
+			local conf = Settings(ctf_map.mapdir .. "/" .. dirname .. "/map.conf")
+			local val = minetest.settings:get("ctf_map." ..
+				string.gsub(dirname, "%./", ""):gsub("/", "."))
 
-			minetest.log("action", "Found map '" .. map.name .. "'")
-			minetest.log("info", dump(map))
-			idx = idx + 1
+			-- If map isn't disabled, load map meta
+			if not conf:get_bool("disabled", false) and val ~= "false" then
+				local map = load_map_meta(idx, dirname, conf)
+				ctf_map.available_maps[idx] = map
+				idx = idx + 1
+
+				minetest.log("info", "Loaded map '" .. map.name .. "'")
+			end
 		end
 	end
 	if not next(ctf_map.available_maps) then
@@ -242,12 +210,12 @@ load_maps()
 minetest.register_chatcommand("maps_reload", {
 	privs = { ctf_admin = true },
 	func = function(name, param)
-		local maps = load_maps()
 		next_idx = nil
 
+		local maps = load_maps()
 		local ret = #maps .. " maps found:\n"
 		for i = 1, #maps do
-			ret = ret .. " * " .. ctf_map.available_maps[i].name
+			ret = ret .. " * " .. maps[i].name
 			if i ~= #maps then
 				ret = ret .. "\n"
 			end
@@ -259,7 +227,7 @@ minetest.register_chatcommand("maps_reload", {
 
 local function place_map(map)
 	ctf_map.emerge_with_callbacks(nil, map.pos1, map.pos2, function()
-		local schempath = ctf_map.mapdir .. map.schematic
+		local schempath = ctf_map.mapdir .. map.dirname .. "/map.mts"
 		local res = minetest.place_schematic(map.pos1, schempath,
 				map.rotation == "z" and "0" or "90")
 
@@ -271,7 +239,7 @@ local function place_map(map)
 
 		local seed = minetest.get_mapgen_setting("seed")
 		for _, chestzone in pairs(ctf_map.map.chests) do
-			minetest.log("info", "Placing " .. chestzone.n .. " chests from " ..
+			minetest.log("verbose", "Placing " .. chestzone.n .. " chests from " ..
 					minetest.pos_to_string(chestzone.from) .. " to "..
 					minetest.pos_to_string(chestzone.to))
 			place_chests(chestzone.from, chestzone.to, seed, chestzone.n)
@@ -352,14 +320,14 @@ ctf_match.register_on_new_match(function()
 					if b_stack:get_name() == t_stack:get_name() and
 							t_stack:get_count() == 1 then
 						is_valid = false
-						minetest.log("action",
+						minetest.log("info",
 								"ctf_map: Omitting treasure - " .. def[1])
 						break
 					end
 				end
 
 				if is_valid then
-					minetest.log("action",
+					minetest.log("info",
 							"ctf_map: Registering treasure - " .. def[1])
 					treasurer.register_treasure(def[1], def[2], def[3], def[4])
 				end

--- a/mods/ctf/ctf_map/time_sky.lua
+++ b/mods/ctf/ctf_map/time_sky.lua
@@ -12,20 +12,20 @@ function ctf_map.update_time()
 	minetest.settings:set("time_speed", BASE_TIME_SPEED * mult)
 end
 
-function ctf_map.skybox_exists(subdir, filename)
+function ctf_map.skybox_exists(subdir)
 	return ctf_map.file_exists(subdir, {
-		filename .. "_skybox_1.png",
-		filename .. "_skybox_2.png",
-		filename .. "_skybox_3.png",
-		filename .. "_skybox_4.png",
-		filename .. "_skybox_5.png",
-		filename .. "_skybox_6.png"
+		"skybox_1.png",
+		"skybox_2.png",
+		"skybox_3.png",
+		"skybox_4.png",
+		"skybox_5.png",
+		"skybox_6.png"
 	})
 end
 
 function ctf_map.set_skybox(player)
 	if ctf_map.map.skybox then
-		local prefix = ctf_map.map.filename .. "_skybox_"
+		local prefix = ctf_map.map.dirname .. "_skybox_"
 		local skybox_textures = {
 			prefix .. "1.png",  -- up
 			prefix .. "2.png",  -- down

--- a/setup_maps.sh
+++ b/setup_maps.sh
@@ -1,0 +1,17 @@
+cd mods/ctf/ctf_map/maps/
+
+# Copy textures from map sub-dirs to ctf_map/textures
+for f in *; do
+	if [ -d ${f} ]; then
+		# Screenshot
+		cp ${f}/screenshot.png ../textures/${f}.png
+
+		# Skybox textures
+		cp ${f}/skybox_1.png ../textures/${f}_skybox_1.png
+		cp ${f}/skybox_2.png ../textures/${f}_skybox_2.png
+		cp ${f}/skybox_3.png ../textures/${f}_skybox_3.png
+		cp ${f}/skybox_4.png ../textures/${f}_skybox_4.png
+		cp ${f}/skybox_5.png ../textures/${f}_skybox_5.png
+		cp ${f}/skybox_6.png ../textures/${f}_skybox_6.png
+	fi
+done

--- a/update.sh
+++ b/update.sh
@@ -1,8 +1,17 @@
-git pull &&
-cd mods/crafting &&
-git pull origin master &&
-cd ../ctf/ctf_map/maps &&
-git pull origin master &&
-cp ./*.png ../textures/ &&
-cd ../../../.. &&
+# Update capturetheflag
+git pull
+
+# Update crafting submodule
+cd mods/crafting
+git pull origin master
+
+# Update maps submodule
+cd ../ctf/ctf_map/maps
+git pull origin master
+
+# Run post-processing actions for maps
+cd ../../../..
+./setup_maps.sh
+
+# Run build.sh
 ./build.sh ../games/capturetheflag


### PR DESCRIPTION
Closes #352. Time to get rid of numeric prefixes for the map files.

- Each map will have its own sub-dir, containing
  - `map.conf` (used to be `<map_name>.conf`)
  - `map.mts` (used to be `<map_name>.mts`)
  - `screenshot.png` (used to be `<map_name>.png`)
  - `skybox_<n>.png` (used to be `<map_name>_skybox_<n>.png`)
- The `ctf_map` post-processing actions for maps has been moved into a dedicated shell script `setup_maps.sh`. This script appropriately renames all the textures to while copying them over to the mod's `textures/` sub-dir. e.g.
    - `cool_map/screenshot.png` ---> `cool_map.png`
    - `awesome_map/skybox_2.png` ---> `awesome_map_skybox_2.png`

****

#### Old directory structure

```
mods/ctf/ctf_map/maps
|
|-- 01_cool_map.conf
|-- 01_cool_map.mts
|-- 01_cool_map.png
|-- 02_awesome_map.conf
|-- 02_awesome_map.mts
|-- 02_awesome_map.png
|-- 02_awesome_map_skybox_1.png
|-- 02_awesome_map_skybox_2.png
|-- 02_awesome_map_skybox_3.png
|-- 02_awesome_map_skybox_4.png
|-- 02_awesome_map_skybox_5.png
\-- 02_awesome_map_skybox_6.png
```

#### New directory structure

```
mods/ctf/ctf_map/maps
|
|-- cool_map/
|   |
|   |-- map.conf
|   |-- map.mts
|   \-- map.png
|
\-- awesome_map/
    |
    |-- map.conf
    |-- map.mts
    |-- screenshot.png
    |-- skybox_1.png
    |-- skybox_2.png
    |-- skybox_3.png
    |-- skybox_4.png
    |-- skybox_5.png
    \-- skybox_6.png
```