### PR TITLE
Implement random spawn within team base

### DIFF
--- a/mods/ctf/ctf_map/base.lua
+++ b/mods/ctf/ctf_map/base.lua
@@ -41,3 +41,18 @@ function ctf_map.place_base(color, pos)
 	inv:add_item("main", ItemStack("default:glass 5"))
 	inv:add_item("main", ItemStack("default:torch 10"))
 end
+
+-- Override ctf.get_spawn to implement random spawns
+local old_spawn = ctf.get_spawn
+function ctf.get_spawn(team)
+	local spawn = old_spawn(team)
+	if not spawn then
+		return
+	end
+
+	return vector.add(spawn, {
+		x = math.random(-1, 1),
+		y = 0,
+		z = math.random(-1, 1)
+	})
+end


### PR DESCRIPTION
Overrides `ctf.get_spawn(team_name)` to return a randomized position within the 3x3 area around the flag.

Idea provided by @Thomas--S in https://github.com/MT-CTF/capturetheflag/issues/131#issuecomment-511699910

#### To test

- Spam `/killme`