### PR TITLE
Remove shooter.conf from shooter's .gitignore, add basic shooter.conf

### DIFF
--- a/mods/pvp/shooter/.gitignore
+++ b/mods/pvp/shooter/.gitignore
@@ -4,5 +4,4 @@
 *bak*
 tags
 *.vim
-shooter.conf
 crosshair.png

--- a/mods/pvp/shooter/shooter.conf
+++ b/mods/pvp/shooter/shooter.conf
@@ -1,0 +1,15 @@
+
+# Disable node destruction with explosives
+SHOOTER_ENABLE_BLASTING = false
+
+# Disable node destruction
+SHOOTER_ALLOW_NODES = false
+
+# Disable extra components
+SHOOTER_ENABLE_FLARES   = false
+SHOOTER_ENABLE_HOOK     = false
+SHOOTER_ENABLE_ROCKETS  = false
+SHOOTER_ENABLE_TURRETS  = false
+
+# Disable crafting
+SHOOTER_ENABLE_CRAFTING = true


### PR DESCRIPTION
This PR:

- Removes `shooter.conf` from `.gitignore`

  The reason being that making the mod's configuration values public would allow people to recreate the exact same server experience. Another benefit of exposing config values is that developers and contributors can collaborate and improve performance-related values to improve the mod's fidelity and accuracy.

- Adds a basic `shooter.conf` that disables node blasting, crafting and also disables components like flare gun, turret gun, and rocket launchers, that are also disabled in the server.

This PR requires confirmation from @rubenwardy that the contents of the proposed `shooter.conf` is at least roughly equivalent to what's on the server's version of the file.

Tested, works.