### PR TITLE
ctf_chat: Add colored PMs

### DIFF
--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -11,6 +11,34 @@ function minetest.is_player_name_valid(name)
 	return name:match("^[%a%d_-]+$")
 end
 
+-- Implement coloured PMs by overriding /msg
+-- The following code has been adapted from the chat-command of the same name in
+-- builtin/game/chat.lua of Minetest <https://github.com/minetest/minetest> licensed
+-- under the GNU LGPLv2.1+ license
+minetest.override_chatcommand("msg", {
+	func = function(name, param)
+		local sendto, message = param:match("^(%S+)%s(.+)$")
+		if not sendto then
+			return false, "Invalid usage, see /help msg."
+		end
+		if not minetest.get_player_by_name(sendto) then
+			return false, "The player " .. sendto .. " is not online."
+		end
+
+		-- Message color
+		local color = minetest.settings:get("ctf_chat.message_color") or "#E043FF"
+
+		-- Colorized sender name and message
+		local str =  minetest.colorize(color, "PM from ")
+		str = str .. minetest.colorize(ctf_colors.get_color(ctf.player(name)).css, name)
+		str = str .. minetest.colorize(color, ": " .. message)
+		minetest.chat_send_player(sendto, str)
+
+		minetest.log("action", "PM from " .. name .. " to " .. sendto .. ": " .. message)
+		return true, "Message sent."
+	end
+})
+
 local function team_console_help(name)
 	minetest.chat_send_player(name, "Try:")
 	minetest.chat_send_player(name, "/team - show team panel")


### PR DESCRIPTION
Continued from MT-CTF/ctf_pvp_engine#37

****

- Sender name is colorized according to their team color
- Message body is colorized according to the setting `ctf_chat.message_color`; defaults to `#E043FF`

![screenshot_20190905_150832](https://user-images.githubusercontent.com/36130650/64332846-f02c9680-cff2-11e9-9eb8-ce543613ec5b.png)

![screenshot_20190905_150652](https://user-images.githubusercontent.com/36130650/64332848-f02c9680-cff2-11e9-9bc8-eefa9356439e.png)
