### PR TITLE
Move suicide check to on_punchplayer callback in ctf

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,7 +15,7 @@ globals = {
 	"crafting", "vector", "table", "minetest", "worldedit", "ctf", "ctf_flag",
 	"ctf_colors", "hudkit", "default", "treasurer", "ChatCmdBuilder", "ctf_map",
 	"ctf_match", "ctf_stats", "ctf_treasure", "ctf_playertag", "chatplus", "irc",
-	"armor", "vote", "give_initial_stuff"
+	"armor", "vote", "give_initial_stuff", "hud_score"
 }
 
 read_globals = {

--- a/mods/ctf/ctf_bounties/init.lua
+++ b/mods/ctf/ctf_bounties/init.lua
@@ -85,7 +85,7 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 ctf.register_on_killedplayer(function(victim, killer)
-	if victim ~= bountied_player or victim == killer then
+	if victim ~= bountied_player then
 		return
 	end
 

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -309,10 +309,6 @@ local function calculateKillReward(victim, killer)
 end
 
 ctf.register_on_killedplayer(function(victim, killer)
-	-- Suicide is not encouraged here at CTF
-	if victim == killer then
-		return
-	end
 	local main, match = ctf_stats.player(killer)
 	if main and match then
 		local reward = calculateKillReward(victim, killer)


### PR DESCRIPTION
Continued from MT-CTF/ctf_pvp_engine#39

****

I've added suicide checks to different `on_killedplayer` callbacks on different occasions, the reason being that all `on_killedplayer` callbacks are designed in a way that require suicide checks. But adding a suicide check to every single callback is far from ideal. Ideally, this should be checked even before the `on_killedplayer` callbacks are run, and that's exactly what this PR does.

Needs testing to ensure nothing is broken.