### PR TITLE
ctf_stats: Add support for retrieving stats by rank

### DIFF
--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -69,6 +69,7 @@ function random_messages.read_messages()
 		"Help your team claim victory by storing extra weapons in the team chest, and never taking more than you need.",
 		"Excessive spawn-killing is a direct violation of the rules - appropriate punishments will be given.",
 		"Use /r to check your score and rank, and /rankings to see the league tables.",
+		"Use /r <number> or /rn <number> to check the rankings of the player in the given rank.",
 		"Use bandages on team-mates to heal them by 3-4 HP if their health is below 15 HP.",
 		"Use /m to add a team marker at pointed location, that's visible only to team-mates.",
 		"Use /summary to check scores of the current match and the previous match.",


### PR DESCRIPTION
- `/r` and `/rankings` now also allow querying player stats by rank. e.g. `/rankings 5` would highlight the 5th highest player in the rankings formspec.
- New chat-command `/rn` (I'm open to renaming this to something better) to retrieve stats by rank (as chat result). This is required to force the argument to be considered as a rank.
- Tons of refactoring in `ctf_stats/gui.lua` to prevent large-scale code duplication. Without all this refactoring, rank-based queries would be a royal pain to implement.

Tested; works perfectly.

### Recommended testing methodology

Execute the following chat-commands with the suggested arguments, and observe that they do what they claim to:

| Command | Expected outcome |
| --- | --- |
| `/r` | Should return caller's stats as chat result |
| `/r <existing_player_name>` | Should return stats of specified player as chat result |
| `/r <rank>` | Should return stats of player at specified rank as chat result |
| `/r <nonexistent_name>` | Should return error message `Invalid player name specified!` |
| `/r <out_of_bounds_rank>` | Should return error message `Number out of bounds!` |
| `/rankings` | Should highlight caller's stats in rankings formspec |
| `/rankings <existing_player_name>` | Should highlight stats of specified player in rankings formspec |
| `/rankings <rank>` | Should highlight stats of player at specified rank in rankings formspec |
| `/rankings <nonexistent_name>` | Should return error message `Invalid player name specified!` |
| `/rankings <out_of_bounds_rank>` | Should return error message `Number out of bounds!` |
| `/rn` | Should return error message `Empty arguments not allowed! Specify a rank.` |
| `/rn <non-number>` | Should return error message `Argument isn't a valid number!` |
| `/rn <rank>` | Should return stats of player at specified rank as chat result |
| `/rn <out_of_bounds_rank>` | Should return error message `Number out of bounds!` |