### PR TITLE
Parameterized /ctf_next; "Skip to map" and "Set as next map" buttons in maps catalog

### DIFF
--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -65,11 +65,11 @@ function ctf_map.get_idx_and_map(param)
 	end
 end
 
-local next_idx
+ctf_map.next_idx = nil
 local function set_next_by_param(name, param)
 	local idx, map = ctf_map.get_idx_and_map(param)
 	if idx then
-		next_idx = idx
+		ctf_map.next_idx = idx
 		return true, "Selected " .. map.name
 	else
 		return false, "Couldn't find any matching map!"
@@ -233,7 +233,7 @@ load_maps()
 minetest.register_chatcommand("maps_reload", {
 	privs = { ctf_admin = true },
 	func = function(name, param)
-		next_idx = nil
+		ctf_map.next_idx = nil
 
 		local maps = load_maps()
 		local ret = #maps .. " maps found:\n"
@@ -290,8 +290,8 @@ ctf_match.register_on_new_match(function()
 
 	-- Choose next map index, but don't select the same one again
 	local idx
-	if next_idx then
-		idx = next_idx
+	if ctf_map.next_idx then
+		idx = ctf_map.next_idx
 	elseif ctf_map.map then
 		idx = math.random(#ctf_map.available_maps - 1)
 		if idx >= ctf_map.map.idx then
@@ -300,7 +300,7 @@ ctf_match.register_on_new_match(function()
 	else
 		idx = math.random(#ctf_map.available_maps)
 	end
-	next_idx = (idx % #ctf_map.available_maps) + 1
+	ctf_map.next_idx = (idx % #ctf_map.available_maps) + 1
 
 	-- Load meta data
 	ctf_map.map = ctf_map.available_maps[idx]


### PR DESCRIPTION
This PR comprises of two commits, I've combined these commits because they kinda go hand-in-hand:

- The first commit adds support for directly passing a map name to `/ctf_next` for immediately skipping to the specified map. Earlier, this had to be done by first invoking `/set_next <map_name>` and then calling `/ctf_next`.
- The second commit adds "Skip to map" and "Set as next map" buttons to the maps catalog, which are the GUI-equivalent of `/ctf_next <map_name>` and `/set_next <map_name>` respectively.

![screenshot_20190913_145322](https://user-images.githubusercontent.com/36130650/64853052-3a87c600-d638-11e9-8fdc-eaf44dd4a6de.png)

### To test

#### First commit (parameterized `/ctf_next`)

- Check if `/ctf_next` skips to the next match and selects a map on its own. This behaviour should be no different from `master`.
- Test skipping to a certain map by invoking `/set_next <map>` and `/ctf_next`, and ensure that the process and outcome is no different from `master`.
- Now skip to a certain map by directly invoking `/ctf_next <map>`. The outcome should be identical to the previous step.

#### Second commit ("Skip to map" and "Set as next map" buttons)

- Test "Set as next map" by pressing the button and invoking `/ctf_next`. The outcome should be identical to invoking `/set_next <map>` and `/ctf_next`.
- Test "Skip to map" by pressing the button. The outcome should be identical to invoking `/ctf_next <map>`.
