### PR TITLE
Implement automatic door closure using node timers

### DIFF
--- a/mods/mtg/doors/init.lua
+++ b/mods/mtg/doors/init.lua
@@ -150,11 +150,8 @@ function _doors.door_toggle(pos, node, clicker)
 
 	replace_old_owner_information(pos)
 
-	local tname = ctf.player(clicker:get_player_name()).team
-	local owner_team = meta:get_string("owner_team")
-	local is_right_team = tname == owner_team
 	if clicker and not minetest.check_player_privs(clicker, "protection_bypass") and
-			not is_right_team then
+			ctf.player(clicker:get_player_name()).team ~= meta:get_string("owner_team") then
 		return false
 	end
 


### PR DESCRIPTION
This PR implements a very simple automatic door closure system using node timers, as an alternative to the relatively complex and lag-inducing idea proposed in #181. The auto-closure timeout, which defaults to 3 seconds, can be adjusted by defining the `doors.auto_closure_timeout` setting. This setting is overkill and probably not needed though, let me know if this should be removed.

- The timer is triggered every time a door is opened. If a timer is already running, it will be reset to the full timeout.
- The timer is aborted if the door is manually closed.
- Once the timer finishes, the node's `on_timer` callback is invoked, which simply calls the door toggle function again.

Tested; works perfectly on both left-hinged and right-hinged doors of all types.

****

Note: This PR also fixes a potential crash when `_doors.door_toggle(pos, node, clicker)` is called where `clicker=nil`; hence the "NO SQUASH".