### PR TITLE
Add a 1000 score threshold to vote in vote kicks

### DIFF
--- a/mods/other/vote/init.lua
+++ b/mods/other/vote/init.lua
@@ -164,8 +164,9 @@ vote.hud = hudkit()
 function vote.update_hud(player)
 	local name = player:get_player_name()
 	local voteset = vote.get_next_vote(name)
+	local player_stats, _ = ctf_stats.player(name)
 	if not voteset or not minetest.check_player_privs(name,
-			{interact=true, vote=true}) then
+			{interact=true, vote=true}) or voteset.can_vote and player_stats.score < 1000 then
 		vote.hud:remove(player, "vote:desc")
 		vote.hud:remove(player, "vote:bg")
 		vote.hud:remove(player, "vote:help")

--- a/mods/other/vote/init.lua
+++ b/mods/other/vote/init.lua
@@ -164,9 +164,8 @@ vote.hud = hudkit()
 function vote.update_hud(player)
 	local name = player:get_player_name()
 	local voteset = vote.get_next_vote(name)
-	local player_stats, _ = ctf_stats.player(name)
 	if not voteset or not minetest.check_player_privs(name,
-			{interact=true, vote=true}) or voteset.can_vote and player_stats.score < 1000 then
+			{interact=true, vote=true}) or voteset.can_vote and not voteset:can_vote(name) then
 		vote.hud:remove(player, "vote:desc")
 		vote.hud:remove(player, "vote:bg")
 		vote.hud:remove(player, "vote:help")

--- a/mods/other/vote/init.lua
+++ b/mods/other/vote/init.lua
@@ -164,11 +164,12 @@ vote.hud = hudkit()
 function vote.update_hud(player)
 	local name = player:get_player_name()
 	local voteset = vote.get_next_vote(name)
-	if not voteset or not minetest.check_player_privs(name,
-			{interact=true, vote=true}) or voteset.can_vote and not voteset:can_vote(name) then
-		vote.hud:remove(player, "vote:desc")
-		vote.hud:remove(player, "vote:bg")
-		vote.hud:remove(player, "vote:help")
+	if not voteset or
+		not minetest.check_player_privs(name,{interact=true, vote=true}) or
+		(voteset.can_vote and not voteset:can_vote(name)) then
+			vote.hud:remove(player, "vote:desc")
+			vote.hud:remove(player, "vote:bg")
+			vote.hud:remove(player, "vote:help")
 		return
 	end
 

--- a/mods/other/vote/init.lua
+++ b/mods/other/vote/init.lua
@@ -164,12 +164,12 @@ vote.hud = hudkit()
 function vote.update_hud(player)
 	local name = player:get_player_name()
 	local voteset = vote.get_next_vote(name)
-	if not voteset or
-		not minetest.check_player_privs(name,{interact=true, vote=true}) or
-		(voteset.can_vote and not voteset:can_vote(name)) then
-			vote.hud:remove(player, "vote:desc")
-			vote.hud:remove(player, "vote:bg")
-			vote.hud:remove(player, "vote:help")
+	if not voteset or not minetest.check_player_privs(name,
+			{interact = true, vote = true}) or
+			(voteset.can_vote and not voteset:can_vote(name)) then
+		vote.hud:remove(player, "vote:desc")
+		vote.hud:remove(player, "vote:bg")
+		vote.hud:remove(player, "vote:help")
 		return
 	end
 

--- a/mods/other/vote/vote_kick.lua
+++ b/mods/other/vote/vote_kick.lua
@@ -59,8 +59,8 @@ minetest.register_chatcommand("vote_kick", {
 			duration = 60,
 			perc_needed = 0.8,
 
-			can_vote = function(self, name)
-				local player_stats, _ = ctf_stats.player(name)
+			can_vote = function(self, pname)
+				local player_stats, _ = ctf_stats.player(pname)
 				local res = true
 					if player_stats.score < 1000 then
 						res = false

--- a/mods/other/vote/vote_kick.lua
+++ b/mods/other/vote/vote_kick.lua
@@ -60,12 +60,7 @@ minetest.register_chatcommand("vote_kick", {
 			perc_needed = 0.8,
 
 			can_vote = function(self, pname)
-				local player_stats, _ = ctf_stats.player(pname)
-				local res = true
-					if player_stats.score < 1000 then
-						res = false
-					end
-				return res
+				return ctf_stats.player(pname).score > 1000
 			end,
 
 			on_result = function(self, result, results)

--- a/mods/other/vote/vote_kick.lua
+++ b/mods/other/vote/vote_kick.lua
@@ -59,6 +59,15 @@ minetest.register_chatcommand("vote_kick", {
 			duration = 60,
 			perc_needed = 0.8,
 
+			can_vote = function(self, name)
+				local player_stats, _ = ctf_stats.player(name)
+				local res = true
+					if player_stats.score < 1000 then
+						res = false
+					end
+				return res
+			end,
+
 			on_result = function(self, result, results)
 				if result == "yes" then
 					minetest.chat_send_all("Vote passed, " ..


### PR DESCRIPTION
Players with score above 1000 can vote in vote kicks but the players whose scores are below 1000 will not be able to vote. This is done to reduce players loging in through multiple accounts to prevent vote kick.