### PR TITLE
ctf_map: Remove unused node ctf_map:ind_stone_red

### DIFF
--- a/mods/ctf/ctf_map/barrier.lua
+++ b/mods/ctf/ctf_map/barrier.lua
@@ -1,9 +1,7 @@
 local c_stone      = minetest.get_content_id("ctf_map:ind_stone")
-local c_stone_red  = minetest.get_content_id("ctf_map:ind_stone_red")
 local c_glass      = minetest.get_content_id("ctf_map:ind_glass")
 local c_glass_red  = minetest.get_content_id("ctf_map:ind_glass_red")
 local c_map_ignore = minetest.get_content_id("ctf_map:ignore")
-local c_actual_st  = minetest.get_content_id("default:stone")
 local c_water      = minetest.get_content_id("default:water_source")
 -- local c_water_f    = minetest.get_content_id("default:water_flowing")
 local c_air        = minetest.get_content_id("air")
@@ -44,8 +42,6 @@ function ctf_map.remove_middle_barrier()
 				else
 					data[vi] = c_air
 				end
-			elseif data[vi] == c_stone_red then
-				data[vi] = c_actual_st
 			end
 		end
 	end

--- a/mods/ctf/ctf_map/nodes.lua
+++ b/mods/ctf/ctf_map/nodes.lua
@@ -46,13 +46,6 @@ do
 		sounds = default.node_sound_glass_defaults()
 	})
 
-	minetest.register_node("ctf_map:ind_stone_red", {
-		description = "Indestructible Red Stone",
-		groups = {immortal = 1},
-		tiles = {"ctf_map_stone_red.png"},
-		is_ground_content = false
-	})
-
 	minetest.register_node("ctf_map:killnode", {
 		description = "Kill Node",
 		drawtype = "glasslike",

--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -4,6 +4,7 @@ minetest.register_alias("mapgen_singlenode", "ctf_map:ignore")
 minetest.register_alias("ctf_map:flag", "air")
 minetest.register_alias("ctf_map:ind_cobble", "ctf_map:cobble")
 minetest.register_alias("ctf_map:ind_stone", "ctf_map:stone")
+minetest.register_alias("ctf_map:ind_stone_red", "default:stone")
 
 minetest.register_alias_force("flowers:mushroom_red", "air")
 minetest.register_alias_force("flowers:mushroom_brown", "air")


### PR DESCRIPTION
This PR removes the largely unused `ctf_map:ind_stone_red` node and all related code. I assume this node was added to replace solid nodes in the barrier, but the problem lies in the fact that there's no way to store the name of the node that was replaced, and the code just replaces these nodes with `default:stone` once the build time ends. I also assume that it's for this very reason this node isn't used when placing barriers either. This PR also adds an alias that replaces these nodes with `default:stone`, as these nodes are in use in the Tunnel and Caverns maps at the moment.

Tested; works - nothing seems to be broken. To test, load up Caverns and ensure that all solid nodes along the middle are `default:stone`. This map originally contains `ctf_map:ind_stone_red` all along the middle barrier, in place of solid nodes.