### PR TITLE
Add colored random messages

### DIFF
--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -79,7 +79,7 @@ end
 function random_messages.display_message(message_number)
 	local msg = random_messages.messages[message_number] or message_number
 	if msg then
-		minetest.chat_send_all(msg)
+		minetest.chat_send_all(minetest.colorize("#12E8F7", msg))
 	end
 end
 

--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -79,7 +79,7 @@ end
 function random_messages.display_message(message_number)
 	local msg = random_messages.messages[message_number] or message_number
 	if msg then
-		minetest.chat_send_all(minetest.colorize("#12E8F7", msg))
+		minetest.chat_send_all(minetest.colorize("#808080", msg))
 	end
 end
 


### PR DESCRIPTION
Adds cyan colored random messages. This is to make sure that the random messages don't easily blend with the normal chat.
![test](https://user-images.githubusercontent.com/42088654/66306065-5a9c6380-e91e-11e9-994a-2396220104c9.png)
![screenshot_20191007_163041](https://user-images.githubusercontent.com/42088654/66306338-0645b380-e91f-11e9-915f-8380c6184c02.png)
