### PR TITLE
Map maker: Add support for optionally specifying node name for team bases

### DIFF
--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -64,6 +64,7 @@ Each map's metadata is stored in an accompanying .conf file containing the follo
 * `author`: Author of the map.
 * `hint`: [Optional] Helpful hint or tip for unique maps, to help players understand the map.
 * `rotation`: Rotation of the schem. [`x`|`z`]
+* `base_node`: [Optional] Technical name of node to be used for the team base.
 * `schematic`: Name of the map's schematic.
 * `initial_stuff`: [Optional] Comma-separated list of itemstacks to be given to the player
  on join and on respawn.

--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -64,6 +64,9 @@ Each map's metadata is stored in an accompanying .conf file containing the follo
 * `author`: Author of the map.
 * `hint`: [Optional] Helpful hint or tip for unique maps, to help players understand the map.
 * `rotation`: Rotation of the schem. [`x`|`z`]
+* `screenshot`: File name of screenshot of the map; should include file extension.
+* `license`: Name of the license of the map.
+* `other`: [Optional] Misc. information about the map. This is displayed in the maps catalog.
 * `base_node`: [Optional] Technical name of node to be used for the team base.
 * `schematic`: Name of the map's schematic.
 * `initial_stuff`: [Optional] Comma-separated list of itemstacks to be given to the player

--- a/mods/ctf/ctf_map/base.lua
+++ b/mods/ctf/ctf_map/base.lua
@@ -1,30 +1,30 @@
 function ctf_map.place_base(color, pos)
-	-- Spawn ind base
+	-- Spawn base
 	for x = pos.x - 2, pos.x + 2 do
-		for z = pos.z - 2, pos.z + 2 do
-			minetest.set_node({ x = x, y = pos.y - 1, z = z },
-				{ name = ctf_map.map.base_node or "ctf_map:ind_cobble" })
-		end
+	for z = pos.z - 2, pos.z + 2 do
+		minetest.set_node({ x = x, y = pos.y - 1, z = z },
+			{ name = ctf_map.map.base_node or "ctf_map:cobble" })
+	end
 	end
 
 	-- Check for trees
-	for y = pos.y, pos.y + 3 do
-		for x = pos.x - 3, pos.x + 3 do
-			for z = pos.z - 3, pos.z + 3 do
-				local pos2 = {x=x, y=y, z=z}
-				if minetest.get_node(pos2).name == "default:tree" then
-					minetest.set_node(pos2, {name="air"})
-				end
-			end
+	for y = pos.y,     pos.y + 3 do
+	for x = pos.x - 3, pos.x + 3 do
+	for z = pos.z - 3, pos.z + 3 do
+		local pos2 = { x = x, y = y, z = z }
+		if minetest.get_node(pos2).name == "default:tree" then
+			minetest.set_node(pos2, { name = "air" })
 		end
+	end
+	end
 	end
 
 	-- Spawn chest
-	local chest = {name = "ctf_map:chest_" .. color}
+	local chest = { name = "ctf_map:chest_" .. color }
 	local dz = 2
 	if pos.z < 0 then
 		dz = -2
-		chest.param2 = minetest.dir_to_facedir({x=0,y=0,z=-1})
+		chest.param2 = minetest.dir_to_facedir({ x = 0, y = 0, z = -1 })
 	end
 	local pos3 = {
 		x = pos.x,

--- a/mods/ctf/ctf_map/base.lua
+++ b/mods/ctf/ctf_map/base.lua
@@ -2,8 +2,8 @@ function ctf_map.place_base(color, pos)
 	-- Spawn ind base
 	for x = pos.x - 2, pos.x + 2 do
 		for z = pos.z - 2, pos.z + 2 do
-			minetest.set_node({ x = x, y = pos.y - 1, z = z},
-				{name = "ctf_map:ind_cobble"})
+			minetest.set_node({ x = x, y = pos.y - 1, z = z },
+				{ name = ctf_map.map.base_node or "ctf_map:ind_cobble" })
 		end
 	end
 

--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -100,6 +100,7 @@ local function load_map_meta(idx, path)
 		screenshot    = meta:get("screenshot"),
 		license       = meta:get("license"),
 		others        = meta:get("others"),
+		base_node     = meta:get("base_node"),
 		schematic     = path .. ".mts",
 		initial_stuff = initial_stuff and initial_stuff:split(","),
 		treasures     = treasures,


### PR DESCRIPTION
This PR adds support for specifying the base node in map meta like so:

```
base_node = <your_node_name_here>
```

A hard-coded base made of indestructible cobble results in ugly cobblestone squares that look completely out of place in all maps except for underground ones. A customisable base allows map makers to get creative, and encourages more extensive theming of the map.

![screenshot_20191009_115726](https://user-images.githubusercontent.com/36130650/66457010-ecc27a00-ea8c-11e9-8ab0-8f1b7b27fe5e.png)

(Screenshot for demonstration only, don't judge me :D)

****

This [no squash] PR also adds missing documentation for a couple of map meta fields, and fixes code-style in `ctf_map/base.lua`.

Tested; works. To test, add `base_node = <valid_node_name>` to the conf file of a map, and play that map.