### PR TITLE
ctf_map: Auto-detect map's screenshot

### DIFF
--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -97,7 +97,7 @@ local function load_map_meta(idx, path)
 		author        = meta:get("author"),
 		hint          = meta:get("hint"),
 		rotation      = meta:get("rotation"),
-		screenshot    = meta:get("screenshot"),
+		screenshot    = path .. ".png",
 		license       = meta:get("license"),
 		others        = meta:get("others"),
 		schematic     = path .. ".mts",
@@ -205,8 +205,9 @@ local function load_maps()
 	local idx = 1
 	ctf_map.available_maps = {}
 	for key, _ in pairs(files_hash) do
+		key = key:gsub("%./", "")
 		local conf = Settings(mapdir .. "/" .. key .. ".conf")
-		local val = minetest.settings:get("ctf.maps." .. key:gsub("%./", ""):gsub("/", "."))
+		local val = minetest.settings:get("ctf.maps." .. key:gsub("/", "."))
 		if not conf:get_bool("disabled", false) and val ~= "false" then
 			local map = load_map_meta(idx, key)
 			map.path = key


### PR DESCRIPTION
If the file name of the screenshot is the exact same name as the map's other files, why not deduce the name automatically (like how we already do to get the schem file)? As we don't allow for different file-names, we might as well auto-deduce the file names of the screenshots instead of having the map maker explicitly define it in the map meta.

This PR doesn't change the behaviour of anything else. 

To test:

- Run `update.sh`, to copy screenshots to the mod's `textures/` dir.
- Launch CTF
- Open the maps catalog. Observe that the screenshots are displayed properly.
