### PR TITLE
Add indestructible torch [ctf_map:torch]

### DIFF
--- a/mods/ctf/ctf_map/nodes.lua
+++ b/mods/ctf/ctf_map/nodes.lua
@@ -76,7 +76,7 @@ do
 	})
 end
 
--- Indestructible nodes from default
+-- Indestructible nodes from MTG's default mod
 do
 	-- Stone
 
@@ -748,7 +748,104 @@ do
 	})
 end
 
--- Register indestructible variants of nodes from stairs and wool
+-- Indestructible torches from MTG's default mod
+do
+	minetest.register_node("ctf_map:torch", {
+		description = "Torch",
+		drawtype = "mesh",
+		mesh = "torch_floor.obj",
+		inventory_image = "default_torch_on_floor.png",
+		wield_image = "default_torch_on_floor.png",
+		tiles = {{
+			name = "default_torch_on_floor_animated.png",
+			animation = {type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 3.3}
+		}},
+		paramtype = "light",
+		paramtype2 = "wallmounted",
+		sunlight_propagates = true,
+		walkable = false,
+		liquids_pointable = false,
+		light_source = 12,
+		groups = {attached_node = 1, torch = 1},
+		drop = "ctf_map:torch",
+		selection_box = {
+			type = "wallmounted",
+			wall_bottom = {-1/8, -1/2, -1/8, 1/8, 2/16, 1/8},
+		},
+		sounds = default.node_sound_wood_defaults(),
+		on_place = function(itemstack, placer, pointed_thing)
+			local under = pointed_thing.under
+			local node = minetest.get_node(under)
+			local def = minetest.registered_nodes[node.name]
+			if def and def.on_rightclick and
+				not (placer and placer:is_player() and
+				placer:get_player_control().sneak) then
+				return def.on_rightclick(under, node, placer, itemstack,
+					pointed_thing) or itemstack
+			end
+
+			local above = pointed_thing.above
+			local wdir = minetest.dir_to_wallmounted(vector.subtract(under, above))
+			local fakestack = itemstack
+			if wdir == 0 then
+				fakestack:set_name("ctf_map:torch_ceiling")
+			elseif wdir == 1 then
+				fakestack:set_name("ctf_map:torch")
+			else
+				fakestack:set_name("ctf_map:torch_wall")
+			end
+
+			itemstack = minetest.item_place(fakestack, placer, pointed_thing, wdir)
+			itemstack:set_name("ctf_map:torch")
+
+			return itemstack
+		end,
+	})
+
+	minetest.register_node("ctf_map:torch_wall", {
+		drawtype = "mesh",
+		mesh = "torch_wall.obj",
+		tiles = {{
+			name = "default_torch_on_floor_animated.png",
+			animation = {type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 3.3}
+		}},
+		paramtype = "light",
+		paramtype2 = "wallmounted",
+		sunlight_propagates = true,
+		walkable = false,
+		light_source = 12,
+		groups = {not_in_creative_inventory = 1, attached_node = 1, torch = 1},
+		drop = "ctf_map:torch",
+		selection_box = {
+			type = "wallmounted",
+			wall_side = {-1/2, -1/2, -1/8, -1/8, 1/8, 1/8},
+		},
+		sounds = default.node_sound_wood_defaults(),
+	})
+
+	minetest.register_node("ctf_map:torch_ceiling", {
+		drawtype = "mesh",
+		mesh = "torch_ceiling.obj",
+		tiles = {{
+			name = "default_torch_on_floor_animated.png",
+			animation = {type = "vertical_frames", aspect_w = 16, aspect_h = 16, length = 3.3}
+		}},
+		paramtype = "light",
+		paramtype2 = "wallmounted",
+		sunlight_propagates = true,
+		walkable = false,
+		light_source = 12,
+		groups = {immortal = 1, not_in_creative_inventory = 1, attached_node = 1, torch = 1},
+		drop = "ctf_map:torch",
+		selection_box = {
+			type = "wallmounted",
+			wall_top = {-1/8, -1/16, -5/16, 1/8, 1/2, 1/8},
+		},
+		sounds = default.node_sound_wood_defaults(),
+	})
+end
+
+-- Register indestructible variants of nodes from MTGs' stairs and wool mods
 do
 	local nodes = table.copy(minetest.registered_nodes)
 	for name, nodedef in pairs(nodes) do


### PR DESCRIPTION
More MTG copy-pasta! This time, from `default/torches.lua`. :D

This PR adds 3 variants of indestructible torches - normal, ceiling-mounted, and wall-mounted. These behave like regular torches in every way, except for their indestructibility.

Tested; works. To test:

- `/giveme ctf_map:torch <how many ever you want>`.
- Run around, placing torches on floors, on walls, and on ceilings.
- Do let me know if you happened to notice something unintended.