### PR TITLE
spawn axes in chests

### DIFF
--- a/mods/ctf/ctf_treasure/init.lua
+++ b/mods/ctf/ctf_treasure/init.lua
@@ -13,6 +13,8 @@ function ctf_treasure.get_default_treasures()
 		{"default:sword_steel",0.4,5,{1,4}},
 		{"default:shovel_stone",0.6,5,{1,10}},
 		{"default:shovel_steel",0.3,5,{1,10}},
+		{"default:axe_steel",0.4,5,{1,10}},
+		{"default:axe_stone",0.5,5,{1,10}},
 
 		{"shooter:crossbow",0.5,2,{1,5}},
 		{"shooter:pistol",0.4,2,{1,5}},


### PR DESCRIPTION
This PR is to spawn iron and stone axes in chests, respectively. The latter is added because on most maps, you do not spawn with an axe.
The reason: Many games are ended by a tunneler that blocks off his tunnel with wood. Because nobody had an axe on hand, he gets away. The same is true for pillarers (stacks of wood in the air), and even just dirty people, messing up the map with a lot of wood everywhere. 
Spawning axes in chests is a trivial thing, but it should have been done a long time ago... The game can be very very frustrating, when someone escapes/captures by using wood. This *should* help change the way CTF PvP goes .. instead of 'who has the more wood', it can be 'who places/digs wood faster' :D Which IMO should level the playing field a bit better.
Tested and it seems to work fine :-)