### PR TITLE
Add support for optionally setting time per-map

### DIFF
--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -73,6 +73,8 @@ Each map's metadata is stored in an accompanying .conf file containing the follo
  on join and on respawn.
 * `treasures`: [Optional] List of treasures to be registered for the map, in a serialized
 format. Refer to the `treasures` sub-section for more details.
+* `start_time`: [Optional] Time at start of match. Defaults to `0.4` [`0` - `1`].
+* `time_speed`: [Optional] Time speed multiplier. Accepts any valid number. Defaults to 1.
 * `r`: Radius of the map.
 * `h`: Height of the map.
 * `team.i`: Name of team `i`.

--- a/mods/ctf/ctf_map/init.lua
+++ b/mods/ctf/ctf_map/init.lua
@@ -20,6 +20,7 @@ if minetest.get_modpath("ctf") then
 	dofile(modpath .. "/base.lua")
 	dofile(modpath .. "/chest.lua")
 	dofile(modpath .. "/give_initial_stuff.lua")
+	dofile(modpath .. "/time.lua")
 	dofile(modpath .. "/schem_map.lua")
 	dofile(modpath .. "/maps_catalog.lua")
 

--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -91,7 +91,9 @@ local function load_map_meta(idx, path)
 
 	local initial_stuff = meta:get("initial_stuff")
 	local treasures = meta:get("treasures")
-	treasures = treasures and treasures:split(";")
+	local start_time = meta:get("start_time")
+	local time_speed = meta:get("time_speed")
+
 	local map = {
 		name          = meta:get("name"),
 		author        = meta:get("author"),
@@ -103,7 +105,9 @@ local function load_map_meta(idx, path)
 		base_node     = meta:get("base_node"),
 		schematic     = path .. ".mts",
 		initial_stuff = initial_stuff and initial_stuff:split(","),
-		treasures     = treasures,
+		treasures     = treasures and treasures:split(";"),
+		start_time    = start_time and tonumber(start_time),
+		time_speed    = time_speed and tonumber(time_speed),
 		r             = tonumber(meta:get("r")),
 		h             = tonumber(meta:get("h")),
 		offset        = offset,
@@ -114,7 +118,7 @@ local function load_map_meta(idx, path)
 	assert(map.r <= max_r)
 
 	map.pos1 = vector.add(offset, { x = -map.r, y = -map.h / 2, z = -map.r })
-	map.pos2 = vector.add(offset, { x =  map.r, y = map.h / 2,  z =  map.r })
+	map.pos2 = vector.add(offset, { x =  map.r, y =  map.h / 2, z =  map.r })
 
 	-- Read teams from config
 	local i = 1
@@ -343,6 +347,9 @@ ctf_match.register_on_new_match(function()
 			end
 		end
 	end
+
+	-- Update time speed
+	ctf_map.update_time()
 
 	-- Place map
 	place_map(ctf_map.map)

--- a/mods/ctf/ctf_map/time.lua
+++ b/mods/ctf/ctf_map/time.lua
@@ -1,0 +1,13 @@
+local BASE_TIME_SPEED = 72
+
+function ctf_map.update_time()
+	local time = ctf_map.map.start_time
+	local mult = ctf_map.map.time_speed or 1
+	if time then
+		minetest.set_timeofday(time)
+	else
+		minetest.set_timeofday(0.4)
+	end
+
+	minetest.settings:set("time_speed", BASE_TIME_SPEED * mult)
+end

--- a/mods/ctf/ctf_match/matches.lua
+++ b/mods/ctf/ctf_match/matches.lua
@@ -41,8 +41,6 @@ function ctf_match.next()
 
 	ctf_alloc.set_all()
 
-	minetest.set_timeofday(0.4)
-
 	minetest.chat_send_all("Next round!")
 	if minetest.global_exists("chatplus") then
 		chatplus.log("Next round!")


### PR DESCRIPTION
This PR adds support for optionally setting start time and time speed per-map, using the `start_time` and `time_speed` map meta fields respectively.

This feature is required by #471. Tested, works.

### Testing

- Add the following to the conf. file of a surface map, and observe that the sun goes to the horizon, and stays there forever:

```
start_time = 0.21
time_speed = 0
```

- Add the following to the conf. file of another surface map, and observe that time traverses 10x faster:

```
time_speed = 10
```

- Also, finish/skip the modified maps, and observe that time works as expected on maps that don't specify these fields.