### PR TITLE
Map maker: Fix barrier rotation and outer barrier placement issues

### DIFF
--- a/mods/ctf/ctf_map/barrier.lua
+++ b/mods/ctf/ctf_map/barrier.lua
@@ -1,4 +1,4 @@
-local c_stone      = minetest.get_content_id("ctf_map:ind_stone")
+local c_stone      = minetest.get_content_id("ctf_map:stone")
 local c_stone_red  = minetest.get_content_id("ctf_map:ind_stone_red")
 local c_glass      = minetest.get_content_id("ctf_map:ind_glass")
 local c_glass_red  = minetest.get_content_id("ctf_map:ind_glass_red")

--- a/mods/ctf/ctf_map/map_maker.lua
+++ b/mods/ctf/ctf_map/map_maker.lua
@@ -222,7 +222,7 @@ local function show_gui(name)
 		"label[0,2.8;2. Place Barriers]",
 		"label[0.1,3.3;This may take a few minutes.]",
 		"field[0.4,4.3;1,1;barrier_r;R;", config.barrier_r, "]",
-		"dropdown[1.15,4.05;1,1;config.barrier_rot;X=0,Z=0;", config.barrier_rot + 1, "]",
+		"dropdown[1.15,4.05;1,1;barrier_rot;X=0,Z=0;", config.barrier_rot + 1, "]",
 		"button[2.3,4;2,1;place_barrier;Place Barriers]",
 
 		"box[4.4,2.8;0.05,2.2;#111111BB]",
@@ -306,7 +306,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	end
 
 	if fields.barrier_rot and fields.barrier_rot ~= "" then
-		config.barrier_rot = fields.config.barrier_rot == "X=0" and 0 or 1
+		config.barrier_rot = fields.barrier_rot == "X=0" and 0 or 1
 		storage:set_int("config.barrier_rot", config.barrier_rot)
 	end
 


### PR DESCRIPTION
The barrier placement code was trying to fetch the content ID of `ctf_map:ind_stone`, which is now just an alias to `ctf_map:stone`, and so returned the CID of air as a fallback. The barrier rotation bug was thanks to some find-and-replace shenanigans. >_<

Tested. Fixes #479.