### PR TITLE
Fix crash upon invoking /maps_reload

### DIFF
--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -244,7 +244,16 @@ minetest.register_chatcommand("maps_reload", {
 	func = function(name, param)
 		local maps = load_maps()
 		next_idx = nil
-		return true, #maps .. " maps found: " .. table.concat(maps, ", ")
+
+		local ret = #maps .. " maps found:\n"
+		for i = 1, #maps do
+			ret = ret .. " * " .. ctf_map.available_maps[i].name
+			if i ~= #maps then
+				ret = ret .. "\n"
+			end
+		end
+
+		return true, ret
 	end,
 })
 


### PR DESCRIPTION
This chat-command was broken ever since `ctf_map.available_maps` contained not just the map name but also cached the map meta of all the loaded maps (i.e. since the advent of maps catalog). The crash was caused because the table passed to `table.concat` wasn't a list of strings. This PR simply fixes this by manually iterating through the list of maps and printing only the names of each map.

Tested, works. Fixes #466.