### PR TITLE
Add support for per-map physics modifiers

### DIFF
--- a/mods/ctf/ctf_map/ctf_map_core/init.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/init.lua
@@ -35,7 +35,7 @@ if minetest.get_modpath("ctf") then
 	dofile(modpath .. "/base.lua")
 	dofile(modpath .. "/chest.lua")
 	dofile(modpath .. "/give_initial_stuff.lua")
-	dofile(modpath .. "/time_sky.lua")
+	dofile(modpath .. "/meta_helpers.lua")
 	dofile(modpath .. "/schem_map.lua")
 	dofile(modpath .. "/maps_catalog.lua")
 

--- a/mods/ctf/ctf_map/ctf_map_core/meta_helpers.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/meta_helpers.lua
@@ -1,6 +1,10 @@
+----------
+-- TIME --
+----------
+
 local BASE_TIME_SPEED = 72
 
-function ctf_map.update_time()
+local function update_time()
 	local time = ctf_map.map.start_time
 	local mult = ctf_map.map.time_speed or 1
 	if time then
@@ -11,6 +15,10 @@ function ctf_map.update_time()
 
 	minetest.settings:set("time_speed", BASE_TIME_SPEED * mult)
 end
+
+------------
+-- SKYBOX --
+------------
 
 function ctf_map.skybox_exists(subdir)
 	return ctf_map.file_exists(subdir, {
@@ -23,7 +31,7 @@ function ctf_map.skybox_exists(subdir)
 	})
 end
 
-function ctf_map.set_skybox(player)
+local function set_skybox(player)
 	if ctf_map.map.skybox then
 		local prefix = ctf_map.map.dirname .. "_skybox_"
 		local skybox_textures = {
@@ -40,14 +48,37 @@ function ctf_map.set_skybox(player)
 	end
 end
 
-function ctf_map.set_skybox_all()
-	for _, player in pairs(minetest.get_connected_players()) do
-		ctf_map.set_skybox(player)
-	end
+-------------
+-- PHYSICS --
+-------------
+
+local function update_physics(player)
+	physics.set(player:get_player_name(), "ctf_map:map_physics", {
+		speed   = ctf_map.map.phys_speed   or 1,
+		jump    = ctf_map.map.phys_jump    or 1,
+		gravity = ctf_map.map.phys_gravity or 1
+	})
 end
+
+---------------
+-- CALLBACKS --
+---------------
 
 minetest.register_on_joinplayer(function(player)
 	if ctf_map.map then
-		ctf_map.set_skybox(player)
+		set_skybox(player)
+		update_physics(player)
 	end
 end)
+
+function ctf_map.update_env()
+	if not ctf_map.map then
+		return
+	end
+
+	update_time()
+	for _, player in pairs(minetest.get_connected_players()) do
+		set_skybox(player)
+		update_physics(player)
+	end
+end

--- a/mods/ctf/ctf_map/ctf_map_core/mod.conf
+++ b/mods/ctf/ctf_map/ctf_map_core/mod.conf
@@ -1,3 +1,3 @@
 name = ctf_map_core
-depends = default
+depends = default, physics
 optional_depends = ctf, ctf_match, ctf_stats, ctf_treasure, stairs, wool, irc

--- a/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
@@ -117,9 +117,9 @@ local function load_map_meta(idx, dirname, meta)
 
 	local map = {
 		dirname       = dirname,
+		name          = meta:get("name"),
 		r             = tonumber(meta:get("r")),
 		h             = tonumber(meta:get("h")),
-		name          = meta:get("name"),
 		author        = meta:get("author"),
 		hint          = meta:get("hint"),
 		rotation      = meta:get("rotation"),
@@ -131,6 +131,9 @@ local function load_map_meta(idx, dirname, meta)
 		start_time    = start_time and tonumber(start_time),
 		time_speed    = time_speed and tonumber(time_speed),
 		skybox        = ctf_map.skybox_exists(dirname),
+		phys_speed    = tonumber(meta:get("phys_speed")),
+		phys_jump     = tonumber(meta:get("phys_jump")),
+		phys_gravity  = tonumber(meta:get("phys_gravity")),
 		offset        = offset,
 		teams         = {},
 		chests        = {}
@@ -365,11 +368,8 @@ ctf_match.register_on_new_match(function()
 	-- Place map
 	place_map(ctf_map.map)
 
-	-- Update time speed
-	ctf_map.update_time()
-
-	-- Update players' skyboxes last
-	ctf_map.set_skybox_all()
+	-- Update per-map env. like time, time speed, skybox, physics, etc.
+	ctf_map.update_env()
 
 	-- Run on_map_loaded callbacks
 	for i = 1, #ctf_map.registered_on_map_loaded do

--- a/mods/ctf/ctf_map/map_maker/README.md
+++ b/mods/ctf/ctf_map/map_maker/README.md
@@ -56,7 +56,14 @@ Each map's metadata is stored in an accompanying .conf file containing the follo
 * `author`: Author of the map.
 * `hint`: [Optional] Helpful hint or tip for unique maps, to help players understand the map.
 * `rotation`: Rotation of the schem. [`x`|`z`]
-* `screenshot`: File name of screenshot of the map; should include file extension.
+* `r`: Radius of the map.
+* `h`: Height of the map.
+* `team.i`: Name of team `i`.
+* `team.i.color`: Color of team `i`.
+* `team.i.pos`: Position of team `i`'s flag, relative to center of schem.
+* `chests.i.from`, `chests.i.to`: [Optional] Positions of diagonal corners of custom chest
+zone `i`, relative to the center of the schem.
+* `chests.i.n`: [Optional] Number of chests to place in custom chest zone `i`.
 * `license`: Name of the license of the map.
 * `other`: [Optional] Misc. information about the map. This is displayed in the maps catalog.
 * `base_node`: [Optional] Technical name of node to be used for the team base.
@@ -67,14 +74,9 @@ Each map's metadata is stored in an accompanying .conf file containing the follo
 format. Refer to the `treasures` sub-section for more details.
 * `start_time`: [Optional] Time at start of match. Defaults to `0.4` [`0` - `1`].
 * `time_speed`: [Optional] Time speed multiplier. Accepts any valid number. Defaults to 1.
-* `r`: Radius of the map.
-* `h`: Height of the map.
-* `team.i`: Name of team `i`.
-* `team.i.color`: Color of team `i`.
-* `team.i.pos`: Position of team `i`'s flag, relative to center of schem.
-* `chests.i.from`, `chests.i.to`: [Optional] Positions of diagonal corners of custom chest
-zone `i`, relative to the center of the schem.
-* `chests.i.n`: [Optional] Number of chests to place in custom chest zone `i`.
+* `phys_speed`: [Optional] Player speed multiplier. Accepts any valid number. Defaults to 1.
+* `phys_jump`: [Optional] Player jump multiplier. Accepts any valid number. Defaults to 1.
+* `phys_gravity`: [Optional] Player gravity multiplier. Accepts any valid number. Defaults to 1.
 
 #### `treasures`
 


### PR DESCRIPTION
Three new map meta fields are now available to map makers:

- `phys_speed`: Speed multiplier
- `phys_jump`: Jump multiplier
- `phys_gravity`: Gravity multiplier

### To test

- Add the following fields to the meta of your favourite map:
  ```
  phys_speed = <whatever>
  phys_jump = <yeah_yeah>
  phys_gravity = <meh>
  ```
- Play CTF, skip to the modified map. Observe that the modified physics roughly matches the values given in the meta.
- Skip to the next match. Observe that the physics values are back to normal.

Tested; works as expected.