### PR TITLE
Invoke ctf_match.next immediately on startup

### DIFF
--- a/mods/ctf/ctf_match/init.lua
+++ b/mods/ctf/ctf_match/init.lua
@@ -37,6 +37,4 @@ if minetest.global_exists("irc") then
 	end)
 end
 
-minetest.after(5, function()
-	ctf_match.next()
-end)
+minetest.after(0, ctf_match.next)


### PR DESCRIPTION
It's wrapped in a `minetest.after(0)` so that it's called only after the server env. is fully loaded. `minetest.register_on_mods_loaded` doesn't work here, which I presume is called before the env. is fully ready.

Earlier, there was a waiting time of 5 seconds, when the player would be floating in the middle of nowhere, and the teams wouldn't be created. There'd also be this annoying error - "No teams to allocate <name> to!".

Tested, works.