### PR TITLE
ctf_stats: Add map name to match summary

### DIFF
--- a/mods/ctf/ctf_map/schem_map.lua
+++ b/mods/ctf/ctf_map/schem_map.lua
@@ -262,6 +262,11 @@ local function place_map(map)
 	end, nil)
 end
 
+ctf_map.registered_on_map_loaded = {}
+function ctf_map.register_on_map_loaded(func)
+	ctf_map.registered_on_map_loaded[#ctf_map.registered_on_map_loaded + 1] = func
+end
+
 ctf_match.register_on_new_match(function()
 	minetest.clear_objects({ mode = "quick" })
 
@@ -343,6 +348,11 @@ ctf_match.register_on_new_match(function()
 
 	-- Update players' skyboxes last
 	ctf_map.set_skybox_all()
+
+	-- Run on_map_loaded callbacks
+	for i = 1, #ctf_map.registered_on_map_loaded do
+		ctf_map.registered_on_map_loaded[i](ctf_map.map)
+	end
 end)
 
 function ctf_match.create_teams()

--- a/mods/ctf/ctf_stats/gui.lua
+++ b/mods/ctf/ctf_stats/gui.lua
@@ -62,6 +62,7 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 
 	local ret = ctf_stats.get_formspec("Match Summary", players, 1)
 
+	-- Winning team and flag capturer name
 	if stats[winner_team] then
 		local winner_color = ctf.flag_colors[winner_team]:gsub("0x", "#")
 		ret = ret .. "item_image[0,0;1,1;ctf_flag:flag_top_"..winner_team.."]"
@@ -73,6 +74,9 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 		ret = ret .. "label[1,0;NO WINNER]"
 	end
 
+	-- Map name
+	ret = ret .. "label[1,7.6;Map: " .. minetest.colorize("#EEEE00", stats.map) .. "]"
+
 	ret = ret .. "label[6.5,0;Kills]"
 	ret = ret .. "label[8,0;" .. render_team_stats(red, blue, "kills") .. "]"
 	ret = ret .. "label[6.5,0.5;Attempts]"
@@ -81,7 +85,7 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 	ret = ret .. "label[12,0;" .. match_length .. "]"
 	ret = ret .. "label[10.5,0.5;Total score]"
 	ret = ret .. "label[12,0.5;" .. render_team_stats(red, blue, "score", true) .. "]"
-	ret = ret .. "label[2,7.75;Tip: type /rankings for league tables]"
+	ret = ret .. "label[8,7.2;Tip: type /rankings for league tables]"
 
 	return ret
 end

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -217,6 +217,14 @@ ctf_match.register_on_new_match(function()
 	_needs_save = true
 end)
 
+-- ctf_map can't be added as a dependency, as that'd result
+-- in cyclic dependencies between ctf_map and ctf_stats
+minetest.after(0, function()
+	ctf_map.register_on_map_loaded(function(map)
+		ctf_stats.current.map = map.name
+	end)
+end)
+
 ctf_flag.register_on_pick_up(function(name, flag)
 	local main, match = ctf_stats.player(name)
 	if main and match then


### PR DESCRIPTION
![screenshot_20191109_173245](https://user-images.githubusercontent.com/36130650/68528333-4a114b80-0317-11ea-8d93-a73f5f2c482c.png)

Opinions and thoughts regarding the placement of the map name is appreciated. Obviously, what looks good on my screen could look completely borked on another screen. That's the inherent limitation of formspecs; hopefully `real_coordinates` would help improve consistency of formspecs across different screens.

Tested; works. Pretty trivial to review and test.
