### PR TITLE
ctf_map: Re-implement random map selection in a better way

### DIFF
--- a/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
@@ -214,7 +214,7 @@ math.randomseed(os.time())
 
 -- Fisher-Yates shuffling algorithm, used for shuffling map selection order
 -- Adapted from snippet provided in https://stackoverflow.com/a/35574006
-local function shuffle_maps()
+local function shuffle_maps(idx_to_avoid)
 	-- Reset shuffled_idx
 	shuffled_idx = 1
 
@@ -229,6 +229,13 @@ local function shuffle_maps()
 	for i = #ctf_map.available_maps, 1, -1 do
 		local j = math.random(i)
 		shuffled_order[i], shuffled_order[j] = shuffled_order[j], shuffled_order[i]
+	end
+
+	-- Prevent the last map of the previous cycle from becoming the first in the next cycle
+	if shuffled_order[1] == idx_to_avoid then
+		print("BETWEEN_order = " .. table.concat(shuffled_order, ", ") .. "\n")
+		local k = math.random(#ctf_map.available_maps - 1)
+		shuffled_order[1], shuffled_order[k + 1] = shuffled_order[k + 1], shuffled_order[1]
 	end
 	print("shuffled_order = " .. table.concat(shuffled_order, ", ") .. "\n\n")
 end
@@ -248,7 +255,7 @@ local function select_map()
 
 		-- If shuffled_idx overflows, re-shuffle map selection order
 		if shuffled_idx > #ctf_map.available_maps then
-			shuffle_maps()
+			shuffle_maps(shuffled_order[#ctf_map.available_maps])
 		end
 	else
 		-- Choose next map index, but don't select the same one again

--- a/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
@@ -223,7 +223,6 @@ local function shuffle_maps(idx_to_avoid)
 	for i = 1, #ctf_map.available_maps, 1 do
 		shuffled_order[i] = i
 	end
-	print("\n\noriginal_order = " .. table.concat(shuffled_order, ", "))
 
 	-- Shuffle table
 	for i = #ctf_map.available_maps, 1, -1 do
@@ -233,11 +232,9 @@ local function shuffle_maps(idx_to_avoid)
 
 	-- Prevent the last map of the previous cycle from becoming the first in the next cycle
 	if shuffled_order[1] == idx_to_avoid then
-		print("BETWEEN_order = " .. table.concat(shuffled_order, ", ") .. "\n")
 		local k = math.random(#ctf_map.available_maps - 1)
 		shuffled_order[1], shuffled_order[k + 1] = shuffled_order[k + 1], shuffled_order[1]
 	end
-	print("shuffled_order = " .. table.concat(shuffled_order, ", ") .. "\n\n")
 end
 
 local random_selection_mode = false
@@ -306,12 +303,6 @@ local function load_maps()
 	if random_selection_mode then
 		shuffle_maps()
 	end
-
-	print("\n\n")
-	for i, map in pairs(ctf_map.available_maps) do
-		print("\t"..i.." | "..map.name)
-	end
-	print("\n\n")
 
 	return ctf_map.available_maps
 end
@@ -385,7 +376,6 @@ ctf_match.register_on_new_match(function()
 	ctf_map.map = ctf_map.available_maps[idx]
 	ctf_map.map.idx = idx
 
-	print("\t\tSelected map idx = "..idx)
 	map_str = "Map: " .. ctf_map.map.name .. " by " .. ctf_map.map.author
 
 	-- Register per-map treasures, or the default set of treasures

--- a/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
@@ -242,12 +242,15 @@ end
 
 local random_selection_mode = false
 local function select_map()
+	local idx
+
 	-- If next_idx exists, return the same
 	if ctf_map.next_idx then
-		return ctf_map.next_idx
+		idx = ctf_map.next_idx
+		ctf_map.next_idx = nil
+		return idx
 	end
 
-	local idx
 	if random_selection_mode then
 		-- Get the real idx stored in table shuffled_order at index [shuffled_idx]
 		idx = shuffled_order[shuffled_idx]


### PR DESCRIPTION
This PR re-implements random map selection, but in a better way. Randomised selection order is employed only if the number of maps >= 10, otherwise the randomness won't be random enough.

### How the randomisation works (only applicable if #maps >= 10)

- Once `load_maps` executes, the map **indices** (not the maps themselves) are shuffled (using Fisher-Yates shuffling algorithm) and stored in a separate table.
- The map selection (now moved to a separate local function) iterates through the table of shuffled indices each time it's called.
- Once the end of the shuffled indices table has been reached, the indices are shuffled again, and are iterated from the beginning once again.

Closes #497. Tested; works perfectly.

Note: I haven't tested this PR after rebasing on top of #435.