### PR TITLE
Disable knockback completely

### DIFF
--- a/mods/ctf/ctf/core.lua
+++ b/mods/ctf/ctf/core.lua
@@ -201,3 +201,8 @@ function ctf.load()
 		ctf.registered_on_new_game[i]()
 	end
 end
+
+-- Disable knockback completely
+function minetest.calculate_knockback()
+	return 0
+end


### PR DESCRIPTION
Originally, I too wanted knockback, and for it to be correctly handled by CTF. But after playing more than a few matches, I'm completely against it. While I do personally hate knockback, personal aversion isn't the reason why I'm opposed to adding it. Here are the reasons why I'm against having knockback in CTF:

- Knockback isn't really suitable for tight many vs many combat, and all the players end up playing football with each other.
- Knockback + lag is horrific, as lag tends to delay the effect of knockback. I've been in this situation countless times, where I finish off an enemy, but the knockback from their punches are applied a couple of seconds later, when I've changed my look direction and my movement direction. I end up being pushed in a completely random direction, losing my head-start to the enemies in pursuit and eventually die.
- Adding slippery nodes into the mix just makes combat oh-so-frustrating. Slippery nodes amplify the already messed-up effect of the knockback, by not allowing me to decelerate as quickly. I end up moonwalking into the warm comforting hands of the enemy. Fun...

Tested; works. To test, fire up two instances of MT (5.1.0+), launch CTF, and punch each other.