### PR TITLE
Fix collision boxes of dead players not being restored on new match

### DIFF
--- a/mods/pvp/collisionbox/init.lua
+++ b/mods/pvp/collisionbox/init.lua
@@ -2,14 +2,27 @@ local collision_box = {}
 
 minetest.register_on_dieplayer(function(player)
 	local name = player:get_player_name()
-	if not collision_box[name] then
-		collision_box[name] = player:get_properties().collisionbox
-	end
-	player:set_properties({collisionbox = {0,0,0, 0,0,0}})
+	collision_box[name] = player:get_properties().collisionbox
+	player:set_properties({ collisionbox = { 0,0,0, 0,0,0 } })
 end)
 
 minetest.register_on_respawnplayer(function(player)
-	player:set_properties({collisionbox = collision_box[player:get_player_name()]})
+	local name = player:get_player_name()
+	player:set_properties({ collisionbox = collision_box[name] })
+	collision_box[name] = nil
+end)
+
+ctf_match.register_on_new_match(function()
+	-- Loop through all dead players and manually reset
+	-- collision box, because on_respawnplayer isn't called
+	-- when the player is respawned at the start of a new match
+	for name, box in pairs(collision_box) do
+		local player = minetest.get_player_by_name(name)
+		if player then
+			player:set_properties({ collisionbox = box })
+		end
+		collision_box[name] = nil
+	end
 end)
 
 minetest.register_on_leaveplayer(function(player)

--- a/mods/pvp/collisionbox/mod.conf
+++ b/mods/pvp/collisionbox/mod.conf
@@ -1,2 +1,3 @@
 name = collisionbox
-description = Changes the collision box of player on death to allow no obstructions when looting or fighting another player.
+depends = ctf_match
+description = Removes the collision box of a player on death to prevent obstructing other players.


### PR DESCRIPTION
The cause of this bug is that `on_respawnplayer` isn't being invoked when the player is "respawned" from code by setting their HP. A workaround to this is to manually restore the collisionboxes of all dead players at the start of a new match, which is exactly what this PR does.

Tested, works. Semi-trivial in terms of size of changes and review/testing required. Closes #506.