### PR TITLE
Add ctf_stats.is_pro; consolidate "pro-ness" calculations

### DIFF
--- a/mods/ctf/ctf_bounties/init.lua
+++ b/mods/ctf/ctf_bounties/init.lua
@@ -27,7 +27,7 @@ local function bounty_player(target)
 	-- bounty_score = -----------, or 500 (whichever is lesser)
 	--                   5000
 
-	local pstat, _ = ctf_stats.player(target)
+	local pstat = ctf_stats.player(target)
 	if pstat.deaths == 0 then
 		pstat.deaths = 1
 	end
@@ -44,7 +44,7 @@ local function bounty_player(target)
 		for _, player in pairs(minetest.get_connected_players()) do
 			local name = player:get_player_name()
 			if bountied_player ~= name then
-				local prev_color = ctf_colors.get_color(prev, ctf.player(prev)).css
+				local prev_color = ctf_colors.get_color(ctf.player(prev)).css
 				minetest.chat_send_player(player:get_player_name(),
 					minetest.colorize("#fff326", "Player ") ..
 					minetest.colorize(prev_color, prev) ..
@@ -60,16 +60,13 @@ local function bounty_find_new_target()
 	local players = {}
 	for _, player in pairs(minetest.get_connected_players()) do
 		local name = player:get_player_name()
-		local pstat, _ = ctf_stats.player(name)
-		pstat.name = name
-		pstat.color = nil
-		if pstat.score > 1000 and pstat.kills > pstat.deaths * 1.5 then
-			table.insert(players, pstat)
+		if ctf_stats.is_pro(name) then
+			table.insert(players, name)
 		end
 	end
 
 	if #players > 0 then
-		bounty_player(players[math.random(1, #players)].name)
+		bounty_player(players[math.random(1, #players)])
 	end
 
 	minetest.after(math.random(500, 1000), bounty_find_new_target)

--- a/mods/ctf/ctf_map/ctf_map_core/chest.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/chest.lua
@@ -6,15 +6,6 @@ local blacklist = {
 	"default:aspen_leaves"
 }
 
-local function max(a, b)
-	return (a > b) and a or b
-end
-
-local function get_is_player_pro(pstat)
-	local kd = pstat.kills / max(pstat.deaths, 1)
-	return pstat.score > 1000 and kd > 1.5
-end
-
 local colors = {"red", "blue"}
 for _, chest_color in pairs(colors) do
 	minetest.register_node("ctf_map_core:chest_" .. chest_color, {
@@ -68,8 +59,7 @@ for _, chest_color in pairs(colors) do
 				"list[current_player;main;0,9.08;8,3;8]",
 			}, "")
 
-			local pstat = ctf_stats.player(name)
-			if not pstat or not pstat.score or pstat.score < 10 then
+			if ctf_stats.player(name).score < 10 then
 				local msg = "You need at least 10 score to access the team chest.\n" ..
 					"Try killing an enemy player, or at least try to capture the flag.\n" ..
 					"Find resources in chests scattered around the map."
@@ -78,7 +68,7 @@ for _, chest_color in pairs(colors) do
 				return
 			end
 
-			local is_pro = get_is_player_pro(pstat)
+			local is_pro = ctf_stats.is_pro(name)
 			local chestinv = "nodemeta:" .. pos.x .. "," .. pos.y .. "," .. pos.z
 
 			formspec = formspec .. "list[" .. chestinv .. ";main;0,0.3;4,7;]" ..
@@ -111,12 +101,11 @@ for _, chest_color in pairs(colors) do
 				return 0
 			end
 
-			local pstat = ctf_stats.player(name)
-			if not pstat or not pstat.score or pstat.score < 10 then
+			if ctf_stats.player(name).score < 10 then
 				return 0
 			end
 
-			if (from_list ~= "pro" and to_list ~= "pro") or get_is_player_pro(pstat) then
+			if (from_list ~= "pro" and to_list ~= "pro") or ctf_stats.is_pro(name) then
 				if to_list == "helper" then
 					-- handle move & overflow
 					local chestinv = minetest.get_inventory({type = "node", pos = pos})
@@ -159,7 +148,7 @@ for _, chest_color in pairs(colors) do
 				return 0
 			end
 
-			if listname ~= "pro" or get_is_player_pro(pstat) then
+			if listname ~= "pro" or ctf_stats.is_pro(name) then
 				local chestinv = minetest.get_inventory({type = "node", pos = pos})
 				if chestinv:room_for_item("pro", stack) then
 					return stack:get_count()
@@ -188,12 +177,11 @@ for _, chest_color in pairs(colors) do
 				return 0
 			end
 
-			local pstat = ctf_stats.player(name)
-			if not pstat or not pstat.score or pstat.score < 10 then
+			if ctf_stats.player(name).score < 10 then
 				return 0
 			end
 
-			if listname ~= "pro" or get_is_player_pro(pstat) then
+			if listname ~= "pro" or ctf_stats.is_pro(name) then
 				return stack:get_count()
 			else
 				return 0

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -195,6 +195,12 @@ function ctf_stats.get_target(name, param)
 	end
 end
 
+function ctf_stats.is_pro(name)
+	local stats = ctf_stats.player(name)
+	local kd = stats.kills / (stats.deaths == 0 and 1 or stats.deaths)
+	return stats.score > 1000 and kd > 1.5
+end
+
 ctf.register_on_join_team(function(name, tname)
 	ctf_stats.current[tname][name] = ctf_stats.current[tname][name] or {
 		kills = 0,

--- a/mods/other/vote/vote_kick.lua
+++ b/mods/other/vote/vote_kick.lua
@@ -57,7 +57,7 @@ minetest.register_chatcommand("vote_kick", {
 			perc_needed = 0.8,
 
 			can_vote = function(self, pname)
-				return ctf_stats.player(pname).score > 1000
+				return ctf_stats.is_pro(name)
 			end,
 
 			on_result = function(self, result, results)


### PR DESCRIPTION
This PR consolidates existing "pro-ness" calculations (basically 1000+ score and 1.5+ K/D) strewn across the code-base into one API function `ctf_stats.is_pro`, and this function call now replaces all individual checks. This would prevent code duplication, and would allow the criteria to be modified more easily without having to sync it across all the existing checks. And more importantly, this is the right way to do it. ;)

Tested; works.