### PR TITLE
ctf_stats: Improve performance by storing a rank-to-name mapping

### DIFF
--- a/mods/ctf/ctf_stats/gui.lua
+++ b/mods/ctf/ctf_stats/gui.lua
@@ -186,7 +186,6 @@ function ctf_stats.get_formspec(title, players, header, target)
 end
 
 function ctf_stats.get_html(title)
-	local players = ctf_stats.get_ordered_players()
 	local ret = "<h1>" .. title .. "</h1>"
 	ret = ret .. "<table>" ..
 		"<tr><th></th>" ..
@@ -199,8 +198,8 @@ function ctf_stats.get_html(title)
 		"<th>Attempts</th>" ..
 		"<th>Score</th></tr>"
 
-	for i = 1, math.min(#players, 50) do
-		local pstat = players[i]
+	for i = 1, math.min(#ctf_stats.ranks, 50) do
+		local pstat = ctf_stats.players[ctf_stats.ranks[i]]
 		local kd = pstat.kills
 		if pstat.deaths > 1 then
 			kd = kd / pstat.deaths


### PR DESCRIPTION
### Summary

This PR implements some rank-to-name mapping to fix some long-term performance issues in `ctf_stats`.

### Implementation

- The most important addition is a newly-added table `ctf_stats.ranks`, which serves as a rank-to-name mapping to simplify stat lookups.
- `ctf_stats.players` is left intact, with the exception of a new field in each player's stats - this field `rank` corresponds to the rank of the player, and also the index in `ctf_stats.ranks`.
- A local function `regenerate_ranks` is used to (re-)generate `ctf_stats.ranks`, and update `rank` field in all existing stats. This function is called on regular intervals to keep the ranks up-to-date.

****

Ready for review; lotsa testing needed.

Partially attends to #313 and #320; although somewhat unrelated, closes #183