### PR TITLE
Tweak scoring algorithm a bit

### DIFF
--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -351,20 +351,20 @@ local function calculateKillReward(victim, killer)
 
 	-- 30 * K/D ratio, with variable based on player's score
 	local kdreward = 30 * vmain.kills / (vmain.deaths + 1)
-	local max = vmain.score / 6
+	local max = vmain.score / 5
 	if kdreward > max then
 		kdreward = max
 	end
-	if kdreward > 80 then
-		kdreward = 80
+	if kdreward > 100 then
+		kdreward = 100
 	end
 	reward = reward + kdreward
 
-	-- Limited to  0 <= X <= 200
-	if reward > 200 then
-		reward = 200
-	elseif reward < 14 then
-		reward = 14
+	-- Limited to  5 <= X <= 250
+	if reward > 250 then
+		reward = 250
+	elseif reward < 5 then
+		reward = 5
 	end
 
 	-- Half if no good weapons


### PR DESCRIPTION
This PR tweaks some constants and upper/lower bounds of the scoring algorithm:

- Maximum score/kill has been increased to 250 from 200. This is because 200 is a weird number and 250 is a nice rounded number. Also, #537 would benefit from this tweak.
- Minimum score/kill has been decreased to 5 from 7. This is to maintain consistency with the "kills since last death" factor, which is multiplied by 5 before being added to the total kill reward. This would result in the score scaling a little more granularly, instead of being rangelim'ed to 7 all the time.
- Maximum reward from K/D factor has been increased to `TotalScore/5` from `TotalScore/6`. Again, this is for consistency with minimum score/kill and "kills since death" factor, and also because 5 is a nice rounded number.

All-in-all, these minor tweaks should allow for a more distributed scoring algorithm, and the score would scale more nicely instead of getting limited to the maximum or minimum, like bounties currently do. I'm planning to make some comparisons using a given set of player stats, to see how much of a difference the tweaks make.