### PR TITLE
Improve match duration metric; move to ctf_match

### DIFF
--- a/mods/ctf/ctf_match/init.lua
+++ b/mods/ctf/ctf_match/init.lua
@@ -15,7 +15,12 @@ ctf.register_on_init(function()
 	minetest.settings:set_bool("enable_pvp", true)
 end)
 
+ctf_match.register_on_build_time_start(function()
+	ctf_match.match_start_time = nil
+end)
+
 ctf_match.register_on_build_time_end(function()
+	ctf_match.match_start_time = os.time()
 	minetest.sound_play({name="ctf_match_attack"}, { gain = 1.0 })
 end)
 

--- a/mods/ctf/ctf_match/matches.lua
+++ b/mods/ctf/ctf_match/matches.lua
@@ -94,3 +94,9 @@ ctf_flag.register_on_capture(function(attname, flag)
 
 	ctf_match.check_for_winner()
 end)
+
+ctf_match.match_start_time = nil
+function ctf_match.get_match_duration()
+	return ctf_match.match_start_time and
+		(os.time() - ctf_match.match_start_time)
+end

--- a/mods/ctf/ctf_stats/chat.lua
+++ b/mods/ctf/ctf_stats/chat.lua
@@ -53,7 +53,7 @@ end
 
 local function summary_func(name)
 	local fs = ctf_stats.get_formspec_match_summary(ctf_stats.current,
-	ctf_stats.winner_team, ctf_stats.winner_player, os.time() - ctf_stats.start)
+	ctf_stats.winner_team, ctf_stats.winner_player, ctf_match.get_match_duration())
 
 	fs = fs .. "button[6,7.5;4,1;b_prev;<< Previous match]"
 

--- a/mods/ctf/ctf_stats/gui.lua
+++ b/mods/ctf/ctf_stats/gui.lua
@@ -58,10 +58,13 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 		blue.score = blue.score + pstat.score
 	end
 
-	local match_length = string.format("%02d:%02d:%02d",
-		math.floor(time / 3600),        -- hours
-		math.floor((time % 3600) / 60), -- minutes
-		math.floor(time % 60))          -- seconds
+	local match_length = "-"
+	if time then
+		match_length = string.format("%02d:%02d:%02d",
+			math.floor(time / 3600),        -- hours
+			math.floor((time % 3600) / 60), -- minutes
+			math.floor(time % 60))          -- seconds
+	end
 
 	local ret = ctf_stats.get_formspec("Match Summary", players, 1)
 
@@ -242,7 +245,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		fs = fs .. "button[6,7.5;4,1;b_curr;Current match >>]"
 	elseif fields.b_curr then
 		fs = ctf_stats.get_formspec_match_summary(ctf_stats.current,
-			ctf_stats.winner_team, ctf_stats.winner_player, os.time() - ctf_stats.start)
+			ctf_stats.winner_team, ctf_stats.winner_player, ctf_match.get_match_duration())
 		fs = fs .. "button[6,7.5;4,1;b_prev;<< Previous match]"
 	else
 		return

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -79,8 +79,6 @@ function ctf_stats.load()
 		blue = {}
 	}
 
-	ctf_stats.start = os.time()
-
 	-- Strip players which have no score
 	for name, player_stats in pairs(ctf_stats.players) do
 		if not player_stats.score or player_stats.score <= 0 then
@@ -241,7 +239,7 @@ ctf_match.register_on_winner(function(winner)
 
 	-- Show match summary
 	local fs = ctf_stats.get_formspec_match_summary(ctf_stats.current,
-		ctf_stats.winner_team, ctf_stats.winner_player, os.time() - ctf_stats.start)
+		ctf_stats.winner_team, ctf_stats.winner_player, ctf_match.get_match_duration())
 
 	for _, player in pairs(minetest.get_connected_players()) do
 		minetest.show_formspec(player:get_player_name(), "ctf_stats:eom", fs)
@@ -258,7 +256,7 @@ ctf_match.register_on_skip_match(function()
 
 	-- Show match summary
 	local fs = ctf_stats.get_formspec_match_summary(ctf_stats.current,
-		ctf_stats.winner_team, ctf_stats.winner_player, os.time() - ctf_stats.start)
+		ctf_stats.winner_team, ctf_stats.winner_player, ctf_match.get_match_duration())
 
 	for _, player in pairs(minetest.get_connected_players()) do
 		minetest.show_formspec(player:get_player_name(), "ctf_stats:eom", fs)
@@ -276,8 +274,12 @@ ctf_match.register_on_new_match(function()
 	}
 	ctf_stats.winner_team = "-"
 	ctf_stats.winner_player = "-"
-	ctf_stats.start = os.time()
 	_needs_save = true
+end)
+
+ctf_stats.start = nil
+ctf_match.register_on_build_time_end(function()
+	ctf_stats.start = os.time()
 end)
 
 -- ctf_map can't be added as a dependency, as that'd result


### PR DESCRIPTION
- Match's start time is initialised only after the buildtime ends. This isn't the case in `master`, and the buildtime is also taken into consideration.
- Since this is a very fundamental metric relating to matches, match duration code has been moved from `ctf_stats` to `ctf_match`.
- A helper function `ctf_match.get_match_duration`, has been added to remove code duplication. Returns `nil` if match start time hasn't been initialised yet.
- If the match summary formspec is displayed when the match start time hasn't been initialised, the duration field in the header would contain `-` instead of `HH:MM:SS`.

#### Testing

- View match summary during build-time. Observe that the header-field duration reads `-`.
- View match summary after build-time ends (`/ctf_start`). Observe that the duration has started only when the build-time ended.
- Complete match. Observe the correct duration being displayed in the end-of-match summary.
- Skip a match during buildtime. Observe the end-of-match summary duration to be `-`.