### PR TITLE
Make ind_glass_red pointable

### DIFF
--- a/mods/ctf/ctf_map/ctf_map_core/nodes.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/nodes.lua
@@ -41,7 +41,7 @@ do
 		buildable_to = false,
 		use_texture_alpha = false,
 		alpha = 0,
-		pointable = false,
+		pointable = true,
 		groups = {immortal = 1},
 		sounds = default.node_sound_glass_defaults()
 	})


### PR DESCRIPTION
This is so players can't take from chests on the other side of the barrier before the round begins.