### PR TITLE
Allow wooden doors in maps

### DIFF
--- a/mods/mtg/doors/init.lua
+++ b/mods/mtg/doors/init.lua
@@ -150,12 +150,13 @@ function _doors.door_toggle(pos, node, clicker)
 
 	replace_old_owner_information(pos)
 
-	local tname = ctf.player(clicker:get_player_name()).team
-	local owner_team = meta:get_string("owner_team")
-	local is_right_team = tname == owner_team
-	if clicker and not minetest.check_player_privs(clicker, "protection_bypass") and
-			not is_right_team then
-		return false
+	-- If team door, check clicker's team
+	if node.name:find("doors:door_steel") then
+		local tname = ctf.player(clicker:get_player_name()).team
+		local owner_team = meta:get_string("owner_team")
+		if clicker and tname ~= owner_team then
+			return false
+		end
 	end
 
 	-- until Lua-5.2 we have no bitwise operators :(


### PR DESCRIPTION
Ever since team doors were added, it became impossible for anyone to operate wooden doors. This is because the code allows only players from the same team as the placer to operate the door, **without checking if the door is actually a team door**. This simple PR fixes this by only checking the operator's team if the door is a team door.

Tested; works.

To help with testing, I've attached an old version of "Hunting season", which has wooden doors. To test, simply play on that map, and verify that the doors can indeed be opened.

[hunting_season.zip](https://github.com/MT-CTF/capturetheflag/files/4015523/hunting_season.zip)
