### PR TITLE
ctf_classes: Temporarily disable rocketeer class

### DIFF
--- a/mods/ctf/ctf_classes/classes.lua
+++ b/mods/ctf/ctf_classes/classes.lua
@@ -78,7 +78,7 @@ ctf_classes.register("medic", {
 	},
 })
 
-ctf_classes.register("rocketeer", {
+--[[ctf_classes.register("rocketeer", {
 	description = "Rocketeer",
 	pros = { "Can craft rockets" },
 	cons = {},
@@ -103,4 +103,4 @@ ctf_classes.register("rocketeer", {
 			"shooter_rocket:rocket"
 		},
 	},
-})
+})]]


### PR DESCRIPTION
The rocketeer class registration has simply been commented out. This fully disables the class, and removes access to the rocketeer's equipment.

Tested; works.