### PR TITLE
Move flag-bearer slowdown to a separate speed modifier

### DIFF
--- a/mods/ctf/ctf_classes/api.lua
+++ b/mods/ctf/ctf_classes/api.lua
@@ -111,13 +111,8 @@ function ctf_classes.update(player)
 	set_max_hp(player, class.properties.max_hp)
 	ctf_classes.set_skin(player, color, class)
 
-	local speed = class.properties.speed
-	if ctf_flag.has_flag(name) and speed > 0.9 then
-		speed = 0.9
-	end
-
 	physics.set(player:get_player_name(), "ctf_classes:speed", {
-		speed = speed,
+		speed = class.properties.speed,
 	})
 
 	crafting.lock_all(player:get_player_name())

--- a/mods/ctf/ctf_match/matches.lua
+++ b/mods/ctf/ctf_match/matches.lua
@@ -80,10 +80,20 @@ function ctf_match.create_teams()
 	error("Error! Unimplemented")
 end
 
+ctf_flag.register_on_pick_up(function(name)
+	physics.set(name, "ctf_match:flag_mult", { speed = 0.9 })
+end)
+
+ctf_flag.register_on_drop(function(name)
+	physics.remove(name, "ctf_match:flag_mult")
+end)
+
 ctf_flag.register_on_capture(function(attname, flag)
 	if not ctf.setting("match.destroy_team") then
 		return
 	end
+
+	physics.remove(attname, "ctf_match:flag_mult")
 
 	local fl_team = ctf.team(flag.team)
 	if fl_team and #fl_team.flags == 0 then


### PR DESCRIPTION
Improves separation; less prone to error.

Kinda identical to #390. 