### PR TITLE
ctf_classes: Fix crash when player meta contains invalid class name

### DIFF
--- a/mods/ctf/ctf_classes/api.lua
+++ b/mods/ctf/ctf_classes/api.lua
@@ -59,7 +59,11 @@ function ctf_classes.get(player)
 		player = minetest.get_player_by_name(player)
 	end
 
-	local cname = player:get_meta():get("ctf_classes:class") or ctf_classes.default_class
+	-- Return class from player meta if valid, or default class
+	local cname = player:get_meta():get("ctf_classes:class")
+	if not ctf_classes.__classes[cname] then
+		cname = ctf_classes.default_class
+	end
 	return ctf_classes.__classes[cname]
 end
 


### PR DESCRIPTION
Fixes the crash upon player join, if the player meta contains an invalid class name. This was possible because there have been a couple of changes across commits that add and remove classes. This PR checks if the meta contains a valid class, and if not, reverts to the default class.

@rubenwardy Do let me know if there's a better solution to this.

### Testing instructions

- Switch to `add_sniper_class` branch (#592). Switch to Sniper class in-game, and quit.
- Checkout this branch again. Run CTF.
- Observe that you're able to join the game without any troubles. This isn't possible in `master`.