### PR TITLE
MTG: Disable mushrooms' HP regen effects

### DIFF
--- a/mods/mtg/flowers/init.lua
+++ b/mods/mtg/flowers/init.lua
@@ -127,7 +127,7 @@ minetest.register_node("flowers:mushroom_red", {
 	buildable_to = true,
 	groups = {mushroom = 1, snappy = 3, attached_node = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
-	on_use = minetest.item_eat(-5),
+	-- on_use = minetest.item_eat(-5),
 	selection_box = {
 		type = "fixed",
 		fixed = {-4 / 16, -0.5, -4 / 16, 4 / 16, -1 / 16, 4 / 16},
@@ -146,7 +146,7 @@ minetest.register_node("flowers:mushroom_brown", {
 	buildable_to = true,
 	groups = {mushroom = 1, food_mushroom = 1, snappy = 3, attached_node = 1, flammable = 1},
 	sounds = default.node_sound_leaves_defaults(),
-	on_use = minetest.item_eat(1),
+	-- on_use = minetest.item_eat(1),
 	selection_box = {
 		type = "fixed",
 		fixed = {-3 / 16, -0.5, -3 / 16, 3 / 16, -2 / 16, 3 / 16},


### PR DESCRIPTION
Tested; works.