### PR TITLE
ctf_stats: API improvements

### DIFF
--- a/mods/ctf/ctf_bounties/init.lua
+++ b/mods/ctf/ctf_bounties/init.lua
@@ -91,6 +91,14 @@ ctf.register_on_killedplayer(function(victim, killer)
 		match.score = match.score + bounty_score
 		main.bounty_kills = main.bounty_kills + 1
 		match.bounty_kills = match.bounty_kills + 1
+
+		ctf_stats.request_save()
+
+		hud_score.new(killer, {
+			name = "ctf_bounty:prize",
+			color = 0x4444FF,
+			value = bounty_score
+		})
 	end
 	bountied_player = nil
 
@@ -102,11 +110,6 @@ ctf.register_on_killedplayer(function(victim, killer)
 		minetest.colorize("#fff326", " and received " .. bounty_score .. " points!")
 	minetest.log("action", minetest.strip_colors(msg))
 	minetest.chat_send_all(msg)
-	hud_score.new(killer, {
-		name = "ctf_bounty:prize",
-		color = 0x4444FF,
-		value = bounty_score
-	})
 end)
 
 minetest.register_privilege("bounty_admin")

--- a/mods/ctf/ctf_classes/medic.lua
+++ b/mods/ctf/ctf_classes/medic.lua
@@ -91,6 +91,8 @@ minetest.override_item("ctf_bandages:bandage", {
 						color = "0x00FF00",
 						value = reward
 					})
+
+					ctf_stats.request_save()
 				end
 			end
 		end

--- a/mods/ctf/ctf_stats/chat.lua
+++ b/mods/ctf/ctf_stats/chat.lua
@@ -161,6 +161,7 @@ minetest.register_chatcommand("reset_rankings", {
 
 		ctf_stats.players[reset_name] = nil
 		ctf_stats.player(reset_name)
+		ctf_stats.request_save()
 
 		if reset_name == name then
 			minetest.log("action", name .. " reset their rankings")
@@ -197,6 +198,8 @@ minetest.register_chatcommand("transfer_rankings", {
 
 		ctf_stats.players[dest] = ctf_stats.players[src]
 		ctf_stats.players[src] = nil
+
+		ctf_stats.request_save()
 
 		minetest.log("action", name .. " transferred stats of " .. src .. " to " .. dest)
 		return true, "Stats of '" .. src .. "' have been transferred to '" .. dest .. "'."

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -57,6 +57,8 @@ function ctf_stats.load_legacy()
 	return true
 end
 
+-- Load persistant data from mod storage (or legacy file)
+-- and initialize empty tables where required
 function ctf_stats.load()
 	if not ctf_stats.load_legacy() then
 		for _, key in pairs(data_to_persist) do
@@ -90,20 +92,26 @@ function ctf_stats.load()
 	end
 end
 
-function ctf_stats.save(force_save)
-	if not _needs_save and not force_save then
-		return
-	end
-
-	_needs_save = false
-
+-- Save persistant data to mod storage
+function ctf_stats.save()
 	for _, key in pairs(data_to_persist) do
 		storage:set_string(key, minetest.write_json(ctf_stats[key]))
 	end
+end
+
+-- Separate recursion to check if save required and then call ctf_stats.save
+-- This allows ctf_stats.save to be called directly when an immediate save is required
+local function check_if_save_needed()
+	if _needs_save then
+		ctf_stats.save()
+		_needs_save = false
+	end
+	minetest.after(13, check_if_save_needed)
+end
+minetest.after(13, check_if_save_needed)
 
 	minetest.after(13, ctf_stats.save)
 end
-minetest.after(13, ctf_stats.save)
 
 function ctf_stats.player_or_nil(name)
 	return ctf_stats.players[name], ctf_stats.current.red[name] or ctf_stats.current.blue[name]
@@ -248,7 +256,8 @@ ctf_match.register_on_winner(function(winner)
 	ctf_stats.prev_match_summary = fs
 	storage:set_string("prev_match_summary", fs)
 
-	ctf_stats.save(true)
+	-- Flush data to mod_storage at the end of each match
+	ctf_stats.save()
 end)
 
 ctf_match.register_on_skip_match(function()
@@ -266,7 +275,7 @@ ctf_match.register_on_skip_match(function()
 	ctf_stats.prev_match_summary = fs
 	storage:set_string("prev_match_summary", fs)
 
-	ctf_stats.save(true)
+	ctf_stats.save()
 end)
 
 ctf_match.register_on_new_match(function()

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -110,7 +110,10 @@ local function check_if_save_needed()
 end
 minetest.after(13, check_if_save_needed)
 
-	minetest.after(13, ctf_stats.save)
+-- API function to allow other mods to request a save
+-- TODO: This should be done automatically once a proper API is in place
+function ctf_stats.request_save()
+	_needs_save = true
 end
 
 function ctf_stats.player_or_nil(name)


### PR DESCRIPTION
- The save-*checking* logic has been separated from the actual save function (`ctf_stats.save`). This would allow mods to directly call `ctf_stats.save` without passing in extra params (like `force_save`).
- New API method `ctf_stats.request_save` - this would allow other mods to set `_needs_save` after modifying player stats. This is temporary, and would be automatically handled when a proper API is in place.

Tested; works. PR is a "no squash", as it contains two different commits.

Partially attends to #579.