### PR TITLE
ctf_classes: Implement cooldown after class change

### DIFF
--- a/mods/ctf/ctf_classes/flags.lua
+++ b/mods/ctf/ctf_classes/flags.lua
@@ -24,7 +24,12 @@ local function on_punch(pos, node, player, ...)
 end
 
 local function show(_, _, player)
-	ctf_classes.show_gui(player:get_player_name(), player)
+	local can_change, reason = ctf_classes.can_change(player)
+	if not can_change then
+		minetest.chat_send_player(player:get_player_name(), reason)
+	else
+		ctf_classes.show_gui(player:get_player_name(), player)
+	end
 end
 
 ctf_flag.on_rightclick = show

--- a/mods/ctf/ctf_classes/gui.lua
+++ b/mods/ctf/ctf_classes/gui.lua
@@ -1,15 +1,10 @@
 function ctf_classes.show_gui(name, player)
 	player = player or minetest.get_player_by_name(name)
 	assert(player.get_player_name)
-	if not ctf_classes.can_change(player) then
-		minetest.chat_send_player(name, "Move closer to your flag to change classes!")
-		return
-	end
 
 	local fs = {
 		"size[", #ctf_classes.__classes_ordered * 3 , ",3.4]"
 	}
-
 
 	local x = 0
 	local y = 0
@@ -79,9 +74,10 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		return false
 	end
 
-	if not ctf_classes.can_change(player) then
-		minetest.chat_send_player(player:get_player_name(),
-				"Move closer to the flag to change classes!")
+	local can_change, reason = ctf_classes.can_change(player)
+	if not can_change then
+		minetest.chat_send_player(player:get_player_name(), reason)
+		return
 	end
 
 	for name in pairs(ctf_classes.__classes) do

--- a/mods/ctf/ctf_classes/init.lua
+++ b/mods/ctf/ctf_classes/init.lua
@@ -15,8 +15,9 @@ dofile(minetest.get_modpath("ctf_classes") .. "/classes.lua")
 minetest.register_on_joinplayer(function(player)
 	ctf_classes.update(player)
 
-	if minetest.check_player_privs(player, { interact = true }) then
-		ctf_classes.show_gui(player:get_player_name())
+	if ctf_classes.can_change(player) and
+			minetest.check_player_privs(player, { interact = true }) then
+		ctf_classes.show_gui(player:get_player_name(), player)
 	end
 end)
 
@@ -27,8 +28,9 @@ minetest.register_chatcommand("class", {
 			return false, "You must be online to do this!"
 		end
 
-		if not ctf_classes.can_change(player) then
-			return false, "Move closer to your flag to change classes!"
+		local can_change, reason = ctf_classes.can_change(player)
+		if not can_change then
+			return false, reason
 		end
 
 		local cname = params:trim()


### PR DESCRIPTION
Defaults to a 30s cooldown. Players with `ctf_admin` priv are exempt from this restriction. Closes #636.

This PR also tweaks `ctf_classes.can_change` to return the reason for failure as a secondary return value, if the primary return value is `false`.

Tested; works as expected.

### To test

- Join as a player without `ctf_admin`.
- Go away from the flag, type `/class`. Should be restricted.
- Go close to the flag:
  - Right-click on the flag. GUI should open.
  - Type `/class`. GUI should open.
- Successfully change your class; repeat steps 2 - 3. Should be restricted.
- Repeat steps 2 - 3 as a player with the `ctf_admin` priv. Shouldn't be restricted.