### PR TITLE
ctf_stats: Improve /makepro chat-command

### DIFF
--- a/mods/ctf/ctf_stats/chat.lua
+++ b/mods/ctf/ctf_stats/chat.lua
@@ -178,9 +178,9 @@ minetest.register_chatcommand("transfer_rankings", {
 	privs = {ctf_admin = true},
 	func = function(name, param)
 		if not param then
-			return false, "Invalid syntax. Provide source and destination player names."
+			return false, "Invalid usage, see /help transfer_rankings"
 		end
-		param = param:trim()
+
 		local src, dest = param:trim():match("([%a%d_-]+) ([%a%d_-]+)")
 		if not src or not dest then
 			return false, "Invalid usage, see /help transfer_rankings"
@@ -205,19 +205,34 @@ minetest.register_chatcommand("transfer_rankings", {
 
 
 minetest.register_chatcommand("makepro", {
-	description = "Make self a pro",
+	params = "[player_name]",
+	description = "Make player a pro",
 	privs = {ctf_admin = true},
 	func = function(name, param)
-		local stats, _ = ctf_stats.player(name)
+		-- Check if param is specified, else target the caller
+		param = param:trim()
+		if param == "" then
+			param = name
+		end
 
-		if stats.kills < 1.5 * (stats.deaths + 1) then
-			stats.kills = 1.51 * (stats.deaths + 1)
+		local modified = false
+		local stats = ctf_stats.player(param)
+
+		local deaths = math.max(stats.deaths, 1)
+		if stats.kills < 1.5 * deaths then
+			stats.kills = math.ceil(1.51 * deaths)
+			modified = true
 		end
 
 		if stats.score < 10000 then
 			stats.score = 10000
+			modified = true
 		end
 
-		return true, "Done"
+		if modified then
+			return true, "Made " .. param .. " a pro!"
+		else
+			return false, param .. " is already a pro!"
+		end
 	end
 })


### PR DESCRIPTION
This PR tweaks the `/makepro` chat-command to provide more meaningful results. Meaningful, as in whole number kills, instead of something like 4.3 kills. :P

### Changes

- `/makepro` can now be used on other players. It will work, even if the said player doesn't exist. This is intentional, and allows for making a new player a pro, without requiring them to already have a score of 1 or more.
- The return string is more intuitive, and conveys target name, and whether the target is already a pro.
- The value assigned to `kills` (to set the K/D higher than 1.5) is rounded off to the next lowest integer (`math.ceil`).

### To test

- Make note of the stats of an existing player. Let's call them "player1".
- Type `/makepro player1`. This should make them a pro, and return "Made player1 a pro!".
- Type `/makepro player1` again. This time, you should get the "player1 is already a pro!" message.
- Type `/reset_rankings player1` and repeat steps 2 - 3. Verify that you get the same results.
- Repeat steps 2 - 4 on a non-existent player. Verify that you get the same results.
- Repeat steps 2 - 4 on yourself. Verify that you get the same results. Use a different account if you don't want to lose your current stats.