### PR TITLE
Add configurable respawn delay

### DIFF
--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -460,6 +460,8 @@ minetest.register_on_prejoinplayer(function(name, ip)
 
 		if time > 0 then
 			return "Kicked: Reason: Leaving the game during respawn timer. You may join again in " .. math.ceil(time) .. " seconds."
+		else
+			respawns[name] = nil
 		end
 	end
 end)


### PR DESCRIPTION
How it works:

When a player dies: store current time in respawns[name].time

When a player respawns: 
    freeze player by attaching them to an invisible immortal object.
    lock player in respawn formspec, telling the user they will respawn in [respawn_time - ((minetest.get_us_time() / 1000000) - respawns[name].time) seconds.
    after duration is over, detach player from and remove object, move them to spawn.

When a player leaves during respawn delay: player is kicked from the server for duration seconds.