### PR TITLE
Award heal score only to medics

### DIFF
--- a/mods/ctf/ctf_classes/medic.lua
+++ b/mods/ctf/ctf_classes/medic.lua
@@ -79,7 +79,7 @@ minetest.override_item("ctf_bandages:bandage", {
 		if ctf.player(pname).team == ctf.player(name).team then
 			local hp = object:get_hp()
 			local limit = ctf_bandages.heal_percent * object:get_properties().hp_max
-			if hp > 0 and hp < limit then
+			if hp > 0 and hp < limit and ctf_classes.get(user).name == "medic" then
 				local main, match = ctf_stats.player(name)
 				if main and match then
 					local reward = 5
@@ -87,7 +87,7 @@ minetest.override_item("ctf_bandages:bandage", {
 					match.score = match.score + reward
 
 					hud_score.new(name, {
-						name = "ctf_stats:heal_score",
+						name = "ctf_classes:medic_heal",
 						color = "0x00FF00",
 						value = reward
 					})


### PR DESCRIPTION
I believe this was the original idea - only medics should be awarded score for healing, because that's their job.

Super-trivial PR. Tested; works.