### PR TITLE
sniper_rifles: Prioritize on un-scoping when right-clicking

### DIFF
--- a/mods/pvp/sniper_rifles/init.lua
+++ b/mods/pvp/sniper_rifles/init.lua
@@ -36,11 +36,13 @@ local function hide_scope(name)
 end
 
 local function on_rclick(item, placer, pointed_thing)
-	if pointed_thing.type == "object" then
-		return
+	local name = placer:get_player_name()
+
+	-- Prioritize on "un-scoping", if player is using the scope
+	if not scoped[name] and pointed_thing.type == "node" then
+		return minetest.item_place(item, placer, pointed_thing)
 	end
 
-	local name = placer:get_player_name()
 	if scoped[name] then
 		hide_scope(name)
 	else
@@ -93,6 +95,7 @@ function sniper_rifles.register_rifle(name, def)
 	-- Manually add extra fields to itemdef that shooter doesn't allow
 	-- Also modify the _loaded variant
 	local overrides = {
+		on_place = on_rclick,
 		on_secondary_use = on_rclick,
 		wield_scale = vector.new(2, 2, 1.5)
 	}


### PR DESCRIPTION
This PR runs `minetest.item_place` (the default `on_place` handler) only if the player isn't scoping. This essentially prioritizes un-scoping over node right-click callbacks when the player is scoped in, because doing things while using a scope is disorienting, and it's assumed that the player wants to unscope first, when they right-click. This also allows for unscoping when pointing at a node without `on_rightclick` callback - this is a god-send as rightclicking on nodes is a very common scenario in tight corridors.

However, this doesn't yet work on nodes with inventories (i.e. treasure chests). I'm yet to figure out how to implement this (help appreciated).

### To test

- Scope-in
- Right-click on doors, team-chest, and any other regular node. Ensure that player scopes out first, and doesn't trigger the nodes' rightclick handler.