### PR TITLE
sniper_rifles: Balance sniper rifles' capabilities

### DIFF
--- a/mods/pvp/sniper_rifles/mod.conf
+++ b/mods/pvp/sniper_rifles/mod.conf
@@ -1,3 +1,3 @@
 name = sniper_rifles
-depends = shooter
-description = This mod adds a couple of sniper rifles that make use of the zoom_fov player property to scope in.
+depends = shooter, physics
+description = Sniper rifle API (depends on shooter) along with couple of sniper rifles.


### PR DESCRIPTION
- Allow firing only when using scope.
- Disable jumping and slow down players to 10% of their speed when scoping in.
  - Seriously, players running around as usual while looking through the scope is the most absurd thing after string theory.

Together, these improve the balance of weapons, and un-OP-ify sniper rifles. Players can no more be fully agile while looking through the scope, and neither can they nail headshots at 100m while hip-firing. Ideally, I'd prefer a more realistic approach of implementing inaccuracy, but that requires a major overhaul of shooter's innards (I prefer to stay away from the innards, as that's the entire point of an API >.>).

Tested; works. Closes #652. I'll make a separate PR to reduce the movement speed of the sniper class to around 90% to 95%.

### To test

- Grab a sniper rifle - it can be either the 7.62mm variant or the Magnum variant.
- Toggle scopes; player should slow down and be unable to jump.
- Fire without scope, and then with scope. Without scope, nothing happens; with scope, rifle should fire normally.
- Verify that an empty rifle does not require scoping in to trigger a reload.