### PR TITLE
Make stone pickaxe capable of breaking cracky=1 nodes

### DIFF
--- a/mods/ctf/ctf_map/ctf_map_core/init.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/init.lua
@@ -26,6 +26,16 @@ function ctf_map.can_cross(player)
 	return false
 end
 
+-- Modify MTG's stone pickaxe to be capable of breaking cracky=1 nodes
+-- Do it here, for lack of a better place
+do
+local tool_caps = minetest.registered_items["default:pick_stone"].tool_capabilities
+tool_caps.groupcaps.cracky.times[1] = 12.0
+minetest.override_item("default:pick_stone", {
+	tool_capabilities = tool_caps
+})
+end
+
 local modpath = minetest.get_modpath(minetest.get_current_modname())
 dofile(modpath .. "/nodes.lua")
 dofile(modpath .. "/emerge.lua")


### PR DESCRIPTION
Tested; works. fixes #660.

Note: Post-merge, this fix needs to be backported to `stable-1` as well.

To test, try breaking `cracky=1` nodes (like reinforced cobble, and mese/diamond ores) using a stone pickaxe - those hardy nodes should take 12s to completely break. Softer nodes like stone and cobblestone should take 4s as before, as this hasn't been changed.