### PR TITLE
Tweak player speed [Attempt 2]

### DIFF
--- a/minetest.conf
+++ b/minetest.conf
@@ -1,17 +1,15 @@
 give_initial_stuff = true
 enable_pvp = true
 mg_name = singlenode
-vote.kick_vote = false
-barrier = 106
+vote.kick_vote = true
 hpregen.interval = 6
 hpregen.amount = 1
 random_messages_interval = 60
 sprint_stamina = 10
-enable_lavacooling = false
 
 #
 # CTF_PVP_ENGINE
-# See mods/ctf_pvp_engine/minetest.conf.example for ctf_pvp_engine settings.
+# See docs/doc_settings.md for ctf_pvp_engine settings.
 #
 
 ctf.colors.skins = true
@@ -43,3 +41,15 @@ ctf.match.destroy_team = true
 ctf.match.reset_on_winner = true
 ctf.match.map_reset_limit = 200
 ctf.match.remove_player_on_leave = true
+
+#
+# Physics
+#
+
+movement_acceleration_default = 4
+movement_acceleration_air = 3
+
+movement_speed_walk = 4.3
+movement_speed_crouch = 1.5
+movement_speed_climb = 3.5
+movement_speed_jump = 7


### PR DESCRIPTION
This is another attempt at tweaking player speeds. The speeds are less extreme this time, unlike #210, which blindly increased all speed-related values. This PR also removes unused settings in minetest.conf, like lava-cooling. Tested; movement feels snappier, while not being as extreme as Quake or Doom, for example.

### To test

Ensure that player movement feels brisk and snappy (shouldn't be extreme) in the following scenarios:

- Walking (with and without sprint)
- Jumping (with and without sprint)
- Sneaking
- Climbing (as in climbing ladders)