### PR TITLE
Fix ranged kill detection

### DIFF
--- a/mods/ctf/ctf_events/init.lua
+++ b/mods/ctf/ctf_events/init.lua
@@ -121,14 +121,13 @@ function ctf_events.update_all()
 end
 
 ctf.register_on_killedplayer(function(victim, killer, stack, tool_caps)
-	local sname = stack:get_name()
 	local type = "sword"
 
 	if tool_caps.damage_groups.grenade then
 		type = "grenade"
 	elseif tool_caps.damage_groups.rocket then
 		type = "rocket"
-	elseif sname:sub(1, 8) == "shooter:" then
+	elseif tool_caps.damage_groups.ranged then
 		type = "bullet"
 	end
 


### PR DESCRIPTION
~~Requires https://github.com/MT-CTF/shooter/pull/2~~ merged
Fixes https://github.com/MT-CTF/capturetheflag/issues/566

**Sniper rifles will be fixed in a separate PR, since I feel like those should have their own icon**

### How to test
* Run `git submodule update --recursive` before you start the step below (Joining the world)
* Join two clients into a world
* Kill the second client with all shooter guns and the crossbow
* You should see the kill list reporting the kills with a pistol image instead of a sword