### PR TITLE
Prevent furnace swapping and fix bug with non-main invs

### DIFF
--- a/mods/ctf/ctf_map/ctf_map_core/chest.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/chest.lua
@@ -219,7 +219,7 @@ for _, chest_color in pairs(colors) do
 
 		if not ctf_map.is_item_allowed_in_team_chest(listname, swapped_item, player) then
 			chestinv:remove_item(listname, swapped_item)
-			player:get_inventory():add_item(listname, swapped_item)
+			player:get_inventory():add_item("main", swapped_item)
 		end
 
 		minetest.log("action", player:get_player_name() ..

--- a/mods/other/tsm_chests/init.lua
+++ b/mods/other/tsm_chests/init.lua
@@ -80,7 +80,7 @@ minetest.register_node("tsm_chests:chest", {
 
 		if swapped_item:get_name() ~= "" then
 			inv:remove_item(listname, swapped_item)
-			player:get_inventory():add_item(listname, swapped_item)
+			player:get_inventory():add_item("main", swapped_item)
 		end
 
 		minetest.log("action", player:get_player_name() ..


### PR DESCRIPTION
### How to test
* Put a non-class item into the node inv (Optional if there is already a non-class item in the inv)
* Take out a non-class item from the node inv and replace a class item in your own inv with it
* Do this with furnaces (active and inactive), loot chests, and both sections of the team chest