### PR TITLE
Add mod `real_suffocation` with custom tweaks for CTF

### DIFF
--- a/mods/other/real_suffocation/README.md
+++ b/mods/other/real_suffocation/README.md
@@ -1,0 +1,24 @@
+# Real Suffocation [`real_suffocation`]
+Version: 1.0.0
+
+This mod adds suffocation. Suffocation is basically the same as drowning, but it
+is for being stuck inside solid blocks. If you're inside a solid block, you lose
+breath. If you lost your breath completely and you're still inside, you suffer
+10 HP (=5 “hearts”) of damage every 2 seconds.
+
+Specifically, suffocation is added to all blocks which:
+
+* Are solid
+* Are full cubes
+* Don't already have built-in damage or drowning damage
+* Are not excluded from suffocations by mods
+
+## Info for modders
+This mod will not add suffocation to all nodes with the group
+`disable_suffocation=1`.
+
+This mod adds the group `real_suffocation=1` to all nodes it has modified,
+this is mostly done for informational purposes.
+
+## License
+Everything is under WTFPL.

--- a/mods/other/real_suffocation/README.md
+++ b/mods/other/real_suffocation/README.md
@@ -21,4 +21,4 @@ This mod adds the group `real_suffocation=1` to all nodes it has modified,
 this is mostly done for informational purposes.
 
 ## License
-Everything is under WTFPL.
+Everything is under the MIT license. Forked from https://repo.or.cz/minetest_real_suffocation.git.

--- a/mods/other/real_suffocation/description.txt
+++ b/mods/other/real_suffocation/description.txt
@@ -1,1 +1,0 @@
-The player will lose breath inside solid blocks.

--- a/mods/other/real_suffocation/description.txt
+++ b/mods/other/real_suffocation/description.txt
@@ -1,0 +1,1 @@
+The player will lose breath inside solid blocks.

--- a/mods/other/real_suffocation/init.lua
+++ b/mods/other/real_suffocation/init.lua
@@ -1,0 +1,56 @@
+-- Load setting
+local suffocation_damage = 2
+local setting = minetest.settings:get("real_suffocation_damage")
+if tonumber(setting) ~= nil then
+	suffocation_damage = tonumber(setting)
+end
+
+-- Skip the rest if suffocation damage is 0, no point in overwriting stuff
+if suffocation_damage > 0 then
+
+-- Checks all nodes and adds suffocation (drowning damage) for suitable nodes
+local function add_suffocation()
+	-- For debugging output
+	local suffocate_nodes = {}
+	local no_suffocate_nodes = {}
+	-- Check ALL the nodes!
+	for itemstring, def in pairs(minetest.registered_nodes) do
+		--[[ Here comes the HUGE conditional deciding whether we use suffocation. We want to catch as many nodes as possible
+		while avoiding bad nodes. We care mostly about physical properties, we don't care about visual appearance.
+		Here's what it checks and why:
+		- Walkable: Must be walkable, which means player can get stuck inside. If player can move freely, suffocation does not make sense
+		- Drowning and damage: If node has set any of those explicitly, it probably knows why. We don't want to mess with it.
+		- collision_box, node_box: Checks whether we deal with full-sized standard cubes, since only care about those.
+			Everything else is probably too small for suffocation to seem real.
+		- disable_suffocation group: If set to 1, we bail out. This makes it possible for nodes to defend themselves against hacking. :-)
+		]]
+		if (def.walkable == nil or def.walkable == true) 
+		and (def.drowning == nil or def.drowning == 0)
+		and (def.damage_per_second == nil or def.damage_per_second <= 0)
+		and (def.collision_box == nil or def.collision_box.type == "regular")
+		and (def.node_box == nil or def.node_box.type == "regular")
+		and (def.groups.disable_suffocation ~= 1)
+		then
+			-- Add “real_suffocation” group so other mods know this node was touched by this mod
+			local marked_groups = def.groups
+			marked_groups.real_suffocation = 1
+			-- Let's hack the node!
+			minetest.override_item(itemstring, { drowning = suffocation_damage, groups = marked_groups })
+			table.insert(suffocate_nodes, itemstring)
+		else
+			table.insert(no_suffocate_nodes, itemstring)
+		end
+	end
+	minetest.log("info", "[real_suffocation] Suffocation has been hacked into "..#suffocate_nodes.." nodes.")
+	minetest.log("verbose", "[real_suffocation] Nodes with suffocation: "..dump(suffocate_nodes))
+	minetest.log("verbose", "[real_suffocation] Suffocation has not been hacked into "..#no_suffocate_nodes.." nodes: "..dump(no_suffocate_nodes))
+end
+
+-- This is a minor hack to make sure our loop runs after all nodes have been registered
+minetest.after(0, add_suffocation)
+
+end
+
+minetest.register_on_joinplayer(function(player)
+    player:set_properties({max_breath = 10})
+end)

--- a/mods/other/real_suffocation/init.lua
+++ b/mods/other/real_suffocation/init.lua
@@ -24,7 +24,7 @@ local function add_suffocation()
 			Everything else is probably too small for suffocation to seem real.
 		- disable_suffocation group: If set to 1, we bail out. This makes it possible for nodes to defend themselves against hacking. :-)
 		]]
-		if (def.walkable == nil or def.walkable == true) 
+		if (def.walkable == nil or def.walkable == true)
 		and (def.drowning == nil or def.drowning == 0)
 		and (def.damage_per_second == nil or def.damage_per_second <= 0)
 		and (def.collision_box == nil or def.collision_box.type == "regular")

--- a/mods/other/real_suffocation/mod.conf
+++ b/mods/other/real_suffocation/mod.conf
@@ -1,0 +1,1 @@
+name = real_suffocation

--- a/mods/other/real_suffocation/mod.conf
+++ b/mods/other/real_suffocation/mod.conf
@@ -1,1 +1,2 @@
 name = real_suffocation
+description = The player will lose breath inside solid blocks.

--- a/mods/other/real_suffocation/settingtypes.txt
+++ b/mods/other/real_suffocation/settingtypes.txt
@@ -1,0 +1,4 @@
+# How much damage is caused by “suffocation” by default, that is, running
+# out of breath while being inside solid blocks like dirt, gravel, sand,
+# etc. Like for drowning, damage is caused every 2 seconds.
+real_suffocation_damage (Suffocation damage) int 10 0

--- a/mods/other/real_suffocation/settingtypes.txt
+++ b/mods/other/real_suffocation/settingtypes.txt
@@ -1,4 +1,4 @@
 # How much damage is caused by “suffocation” by default, that is, running
 # out of breath while being inside solid blocks like dirt, gravel, sand,
 # etc. Like for drowning, damage is caused every 2 seconds.
-real_suffocation_damage (Suffocation damage) int 10 0
+real_suffocation_damage (Suffocation damage) int 2 0


### PR DESCRIPTION
Players now slowly suffocate inside nodes, since they should not be in blocks they cannot obtain, I have left this feature (damage instead of suffocation in blocks they cannot obtain) out for the moment. 

Also, players only have half as much breath as before.

There is no way to damage in water less than `1`, so putting this up here, feel free to suggest changes in regards to making water similar to how it was before.