### PR TITLE
Shooter Class Ammo

### DIFF
--- a/mods/ctf/ctf_classes/classes.lua
+++ b/mods/ctf/ctf_classes/classes.lua
@@ -35,7 +35,7 @@ ctf_classes.register("shooter", {
 			"shooter_hook:grapple_gun_loaded",
 			"shooter:ammo 2"
 		},
-		
+
 		item_blacklist = {
 			"shooter_guns:rifle_loaded",
 			"shooter_hook:grapple_gun_loaded",

--- a/mods/ctf/ctf_classes/classes.lua
+++ b/mods/ctf/ctf_classes/classes.lua
@@ -33,6 +33,12 @@ ctf_classes.register("shooter", {
 		initial_stuff = {
 			"shooter_guns:rifle_loaded",
 			"shooter_hook:grapple_gun_loaded",
+			"shooter:ammo 2"
+		},
+		
+		item_blacklist = {
+			"shooter_guns:rifle_loaded",
+			"shooter_hook:grapple_gun_loaded",
 		},
 
 		additional_item_blacklist = {


### PR DESCRIPTION
Gives shooter class 2 ammo packs 
Useful for late game when ammo from loot chests has just about dryed up and on some maps mining is not possible