### PR TITLE
Add Team K/D to summary

### DIFF
--- a/mods/ctf/ctf_stats/gui.lua
+++ b/mods/ctf/ctf_stats/gui.lua
@@ -32,12 +32,14 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 	local red = {
 		color = ctf.flag_colors.red:gsub("0x", "#"),
 		kills = 0,
+		deaths = 0,
 		attempts = 0,
 		score = 0,
 	}
 	local blue = {
 		color = ctf.flag_colors.blue:gsub("0x", "#"),
 		kills = 0,
+		deaths = 0,
 		attempts = 0,
 		score = 0,
 	}
@@ -46,6 +48,7 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 		pstat.color = ctf.flag_colors.red
 		table.insert(players, pstat)
 		red.kills = red.kills + pstat.kills
+		red.deaths = red.deaths + pstat.deaths
 		red.attempts = red.attempts + pstat.attempts
 		red.score = red.score + pstat.score
 	end
@@ -54,6 +57,7 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 		pstat.color = ctf.flag_colors.blue
 		table.insert(players, pstat)
 		blue.kills = blue.kills + pstat.kills
+		blue.deaths = blue.deaths + pstat.deaths
 		blue.attempts = blue.attempts + pstat.attempts
 		blue.score = blue.score + pstat.score
 	end
@@ -65,6 +69,16 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 			math.floor((time % 3600) / 60), -- minutes
 			math.floor(time % 60))          -- seconds
 	end
+	
+		local red_kd = math.floor(red.kills / red.deaths * 10) / 10
+		if red.deaths <1 then
+			red_kd = red.kills
+    end
+	
+	local blue_kd = math.floor(blue.kills / blue.deaths * 10) / 10
+		if blue.deaths <1 then
+			blue_kd = blue.kills
+    end
 
 	local ret = ctf_stats.get_formspec("Match Summary", players, 1)
 
@@ -83,10 +97,13 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 	-- Map name
 	ret = ret .. "label[1,7.6;Map: " .. minetest.colorize("#EEEE00", stats.map) .. "]"
 
-	ret = ret .. "label[6,0;Kills]"
-	ret = ret .. "label[7.5,0;" .. render_team_stats(red, blue, "kills") .. "]"
-	ret = ret .. "label[6,0.5;Attempts]"
-	ret = ret .. "label[7.5,0.5;" .. render_team_stats(red, blue, "attempts") .. "]"
+	ret = ret .. "label[6.5,0;Kills]"
+	ret = ret .. "label[8,0;" .. render_team_stats(red, blue, "kills") .. "]"
+	ret = ret .. "label[3.5,0.5;Team K/D]"
+	ret = ret .. "label[5,0.5;" .. minetest.colorize(red.color, tostring(red_kd))
+		.. " - " .. " " .. minetest.colorize(blue.color, tostring(blue_kd)) .. "]"
+	ret = ret .. "label[6.5,0.5;Attempts]"
+	ret = ret .. "label[8,0.5;" .. render_team_stats(red, blue, "attempts") .. "]"
 	ret = ret .. "label[9.5,0;Duration]"
 	ret = ret .. "label[11,0;" .. match_length .. "]"
 	ret = ret .. "label[9.5,0.5;Total score]"
@@ -252,3 +269,4 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
 	minetest.show_formspec(player:get_player_name(), "ctf_stats:match_summary", fs)
 end)
+

--- a/mods/ctf/ctf_stats/gui.lua
+++ b/mods/ctf/ctf_stats/gui.lua
@@ -269,4 +269,3 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 
 	minetest.show_formspec(player:get_player_name(), "ctf_stats:match_summary", fs)
 end)
-

--- a/mods/ctf/ctf_stats/gui.lua
+++ b/mods/ctf/ctf_stats/gui.lua
@@ -69,16 +69,14 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 			math.floor((time % 3600) / 60), -- minutes
 			math.floor(time % 60))          -- seconds
 	end
-	
 		local red_kd = math.floor(red.kills / red.deaths * 10) / 10
 		if red.deaths <1 then
 			red_kd = red.kills
-    end
-	
+	end
 	local blue_kd = math.floor(blue.kills / blue.deaths * 10) / 10
 		if blue.deaths <1 then
 			blue_kd = blue.kills
-    end
+	end
 
 	local ret = ctf_stats.get_formspec("Match Summary", players, 1)
 
@@ -99,8 +97,8 @@ function ctf_stats.get_formspec_match_summary(stats, winner_team, winner_player,
 
 	ret = ret .. "label[6.5,0;Kills]"
 	ret = ret .. "label[8,0;" .. render_team_stats(red, blue, "kills") .. "]"
-	ret = ret .. "label[3.5,0.5;Team K/D]"
-	ret = ret .. "label[5,0.5;" .. minetest.colorize(red.color, tostring(red_kd))
+	ret = ret .. "label[3.5,0;Team K/D]"
+	ret = ret .. "label[5,0;" .. minetest.colorize(red.color, tostring(red_kd))
 		.. " - " .. " " .. minetest.colorize(blue.color, tostring(blue_kd)) .. "]"
 	ret = ret .. "label[6.5,0.5;Attempts]"
 	ret = ret .. "label[8,0.5;" .. render_team_stats(red, blue, "attempts") .. "]"


### PR DESCRIPTION
These changes will add "Team K/D" to summary counted from red and blue kills and deaths.