### PR TITLE
Make bounties more scalable

### DIFF
--- a/mods/ctf/ctf_bounties/init.lua
+++ b/mods/ctf/ctf_bounties/init.lua
@@ -23,6 +23,20 @@ local function bounty_player(target)
 	local prev = bountied_player
 	bountied_player = target
 
+	-- Players with less than 20000 points --> bounty 50
+	--
+	-- ########################################################
+	--
+	-- Players between 20000 points and 50000 points:
+	--
+	--                  Score
+	-- bounty_score = ----------, or 500 (whichever is lesser)
+	--                  deaths
+	--
+	-- ########################################################
+	--
+	-- Players with more than 50000 points:
+	--
 	--                 Score * 2
 	-- bounty_score = -----------, or 500 (whichever is lesser)
 	--                  deaths
@@ -31,7 +45,17 @@ local function bounty_player(target)
 	if pstat.deaths == 0 then
 		pstat.deaths = 1
 	end
-	bounty_score = ((pstat.score * 2) / pstat.deaths)
+
+	if pstat.score <= 20000 then
+		bounty_score = 50
+	end
+	if ((pstat.score > 20000) and (pstat.score <= 50000)) then
+		bounty_score = (pstat.score / pstat.deaths)
+	end
+	if pstat.score > 50000 then
+		bounty_score = ((pstat.score * 2) / pstat.deaths)
+	end
+
 	if bounty_score > 500 then
 		bounty_score = 500
 	end

--- a/mods/ctf/ctf_bounties/init.lua
+++ b/mods/ctf/ctf_bounties/init.lua
@@ -48,7 +48,7 @@ local function bounty_player(target)
 
 	if pstat.score <= 20000 then
 		bounty_score = 50
-	elseif ((pstat.score > 20000) and (pstat.score <= 50000)) then
+	elseif pstat.score <= 50000 then
 		bounty_score = (pstat.score / pstat.deaths)
 	else
 		bounty_score = ((pstat.score * 2) / pstat.deaths)

--- a/mods/ctf/ctf_bounties/init.lua
+++ b/mods/ctf/ctf_bounties/init.lua
@@ -48,11 +48,9 @@ local function bounty_player(target)
 
 	if pstat.score <= 20000 then
 		bounty_score = 50
-	end
-	if ((pstat.score > 20000) and (pstat.score <= 50000)) then
+	elseif ((pstat.score > 20000) and (pstat.score <= 50000)) then
 		bounty_score = (pstat.score / pstat.deaths)
-	end
-	if pstat.score > 50000 then
+	else
 		bounty_score = ((pstat.score * 2) / pstat.deaths)
 	end
 

--- a/mods/ctf/ctf_bounties/init.lua
+++ b/mods/ctf/ctf_bounties/init.lua
@@ -23,15 +23,15 @@ local function bounty_player(target)
 	local prev = bountied_player
 	bountied_player = target
 
-	--                Score * K/D
+	--                 Score * 2
 	-- bounty_score = -----------, or 500 (whichever is lesser)
-	--                   5000
+	--                  deaths
 
 	local pstat = ctf_stats.player(target)
 	if pstat.deaths == 0 then
 		pstat.deaths = 1
 	end
-	bounty_score = (pstat.score * (pstat.kills / pstat.deaths)) / 10000
+	bounty_score = ((pstat.score * 2) / pstat.deaths)
 	if bounty_score > 500 then
 		bounty_score = 500
 	end


### PR DESCRIPTION
Issue #268 

> Bounty prizes are calculated using the following algorithm: (score * KD) / 5000. To prevent extreme bounty prizes, there's a hard upper and lower limit of 500 and 50 respectively. What happens here is that unless a player's score and KD are within a certain magical range, the bounty on their heads is always 50 or 500, because the algorithm generally returns a number outside the permitted range.
> 
> It would be great if the bounty was somehow made to scale within the 50-500 range in the first place. The lower limit should also be reduced to 5 or 10.

I changed to `(score * 2)/deaths` (average points per death * 2) so is is a lot more scalable.
![Zaslonska slika 2020-12-14 08-49-30](https://user-images.githubusercontent.com/47271658/102056335-818cda00-3dec-11eb-9634-bb9f4fb28079.png)
![Zaslonska slika 2020-12-14 08-49-45](https://user-images.githubusercontent.com/47271658/102056339-83569d80-3dec-11eb-9553-144597f2675d.png)

Bounties for top 10 players:

![Zaslonska slika 2020-12-14 09-14-57](https://user-images.githubusercontent.com/47271658/102056589-e1838080-3dec-11eb-9c13-40bd4073e09f.png)