### PR TITLE
Fix bug with crosshairs active after death

### DIFF
--- a/mods/pvp/sniper_rifles/init.lua
+++ b/mods/pvp/sniper_rifles/init.lua
@@ -22,13 +22,6 @@ local default_physics_overrides = {
 	jump = 0
 }
 
--- Fix crosshair still showing after death with a simple check
-minetest.register_on_dieplayer(function(player)
-	if scoped_hud_id[player:get_player_name()] then
-		scoped_hud_id[player:get_player_name()] = nil
-	end
-end)
-
 -------------
 -- Helpers --
 -------------
@@ -69,6 +62,13 @@ local function hide_scope(name)
 	player:hud_set_flags({ wielditem = true })
 
 end
+
+-- Fix crosshair still showing after death with a simple check
+minetest.register_on_dieplayer(function(player)
+	if scoped_hud_id[player:get_player_name()] then
+		hide_scope(player:get_player_name())
+	end
+end)
 
 local function on_use(stack, user, pointed)
 	if scoped[user:get_player_name()] then

--- a/mods/pvp/sniper_rifles/init.lua
+++ b/mods/pvp/sniper_rifles/init.lua
@@ -63,7 +63,7 @@ local function hide_scope(name)
 
 end
 
--- Fix crosshair still showing after death with a simple check
+-- Be absolutely certain crosshair HUD gets removed on death
 minetest.register_on_dieplayer(function(player)
 	if scoped_hud_id[player:get_player_name()] then
 		hide_scope(player:get_player_name())
@@ -97,7 +97,7 @@ local function on_rclick(item, placer, pointed_thing)
 end
 
 ------------------
--- Sccope-check --
+-- Scope-check --
 ------------------
 
 -- Hide scope if currently wielded item is not the same item

--- a/mods/pvp/sniper_rifles/init.lua
+++ b/mods/pvp/sniper_rifles/init.lua
@@ -22,6 +22,13 @@ local default_physics_overrides = {
 	jump = 0
 }
 
+-- Fix crosshair still showing after death with a simple check
+minetest.register_on_dieplayer(function(player)
+	if scoped_hud_id[player:get_player_name()] then
+		scoped_hud_id[player:get_player_name()] = nil
+	end
+end)
+
 -------------
 -- Helpers --
 -------------


### PR DESCRIPTION
(hopefully) fixes issue with crosshairs remaining after player death. Requires testing.
How to test:
- die while scoped

Normally I would do this but I am unable to get to a proper platform to test. Thanks!