### PR TITLE
Remove hook if player has changed their class after firing the hook

### DIFF
--- a/mods/ctf/ctf_classes/ranged.lua
+++ b/mods/ctf/ctf_classes/ranged.lua
@@ -86,11 +86,10 @@ minetest.registered_entities["shooter_hook:hook"].on_step = function(self, dtime
 		return
 	end
 
-	-- Remove hook if player has changed
-	-- their class after firing the hook.
+	-- Remove hook if player changes class after throwing it
 	if not ctf_classes.get(self.user).properties.allow_grapples then
 		minetest.chat_send_player(self.user,
-			"You can't fire grapples and change your class!")
+			"Grapples don't work if you change class!")
 		self.object:remove()
 		return
 	end

--- a/mods/ctf/ctf_classes/ranged.lua
+++ b/mods/ctf/ctf_classes/ranged.lua
@@ -89,12 +89,8 @@ minetest.registered_entities["shooter_hook:hook"].on_step = function(self, dtime
 	-- Remove hook if player has changed
 	-- their class after firing the hook.
 	if not ctf_classes.get(self.user).properties.allow_grapples then
-		local player = minetest.get_player_by_name(self.user)
-		if player then
-			player:get_inventory():add_item("main", "shooter_hook:grapple_hook")
-		end
 		minetest.chat_send_player(self.user,
-			"Your class can't use that weapon! Change your class at spawn")
+			"You can't fire grapples and change your class!")
 		self.object:remove()
 		return
 	end

--- a/mods/ctf/ctf_classes/ranged.lua
+++ b/mods/ctf/ctf_classes/ranged.lua
@@ -85,5 +85,19 @@ minetest.registered_entities["shooter_hook:hook"].on_step = function(self, dtime
 		self.object:remove()
 		return
 	end
+
+	-- Remove hook if player has changed
+	-- their class after firing the hook.
+	if not ctf_classes.get(self.user).properties.allow_grapples then
+		local player = minetest.get_player_by_name(self.user)
+		if player then
+			player:get_inventory():add_item("main", "shooter_hook:grapple_hook")
+		end
+		minetest.chat_send_player(self.user,
+			"Your class can't use that weapon! Change your class at spawn")
+		self.object:remove()
+		return
+	end
+
 	return old_grapple_step(self, dtime, ...)
 end


### PR DESCRIPTION
Things added/changed:

- Remove hook if player has changed their class after firing the hook.
  - This prevents users from firing the hook, change their class and teleport to their destination.

Tested with MT `5.4.0-c490a57a3-c940a57a3-dirty`.
