### PR TITLE
Fix bug with medkits not allocating deaths and score after death properly

### DIFF
--- a/mods/pvp/medkits/init.lua
+++ b/mods/pvp/medkits/init.lua
@@ -134,7 +134,6 @@ minetest.register_on_player_hpchange(function(player, hp, reason)
 	if hp < 0 then
 		if players[name] then
 			players[name] = nil -- Don't use stop_healing(), it uses set_hp() and won't allocate deaths or score properly
-			minetest.chat_send_player(name, minetest.colorize("#FF4444", "Your healing was interrupted"..reason_handler("damage")))
 			player:hud_remove(players[name].hud)
 		end
 		if reason and reason.type == "punch" then

--- a/mods/pvp/medkits/init.lua
+++ b/mods/pvp/medkits/init.lua
@@ -133,8 +133,8 @@ minetest.register_on_player_hpchange(function(player, hp, reason)
 	local name = player:get_player_name()
 	if hp < 0 then
 		if players[name] then
-			players[name] = nil -- Don't use stop_healing(), it uses set_hp() and won't allocate deaths or score properly
 			player:hud_remove(players[name].hud)
+			players[name] = nil -- Don't use stop_healing(), it uses set_hp() and won't allocate deaths or score properly
 		end
 		if reason and reason.type == "punch" then
 			local hitter = reason.object

--- a/mods/pvp/medkits/init.lua
+++ b/mods/pvp/medkits/init.lua
@@ -134,6 +134,7 @@ minetest.register_on_player_hpchange(function(player, hp, reason)
 		if players[player:get_player_name()] then
 			players[player:get_player_name()] = nil -- Don't use stop_healing(), it uses set_hp() and won't allocate deaths or score properly
 			minetest.chat_send_player(name, minetest.colorize("#FF4444", "Your healing was interrupted"..reason_handler("damage")))
+			player:hud_remove(players[player:get_player_name()].hud)
 		end
 		if reason and reason.type == "punch" then
 			local hitter = reason.object

--- a/mods/pvp/medkits/init.lua
+++ b/mods/pvp/medkits/init.lua
@@ -132,7 +132,8 @@ end)
 minetest.register_on_player_hpchange(function(player, hp, reason)
 	if hp < 0 then
 		if players[player:get_player_name()] then
-			stop_healing(player, "damage")
+			players[player:get_player_name()] = nil -- Don't use stop_healing(), it uses set_hp() and won't allocate deaths or score properly
+			minetest.chat_send_player(name, minetest.colorize("#FF4444", "Your healing was interrupted"..reason_handler("damage")))
 		end
 		if reason and reason.type == "punch" then
 			local hitter = reason.object

--- a/mods/pvp/medkits/init.lua
+++ b/mods/pvp/medkits/init.lua
@@ -130,11 +130,12 @@ end)
 -- If player takes damage while healing,
 -- stop regen and revert back to original state
 minetest.register_on_player_hpchange(function(player, hp, reason)
+	local name = player:get_player_name()
 	if hp < 0 then
-		if players[player:get_player_name()] then
-			players[player:get_player_name()] = nil -- Don't use stop_healing(), it uses set_hp() and won't allocate deaths or score properly
+		if players[name] then
+			players[name] = nil -- Don't use stop_healing(), it uses set_hp() and won't allocate deaths or score properly
 			minetest.chat_send_player(name, minetest.colorize("#FF4444", "Your healing was interrupted"..reason_handler("damage")))
-			player:hud_remove(players[player:get_player_name()].hud)
+			player:hud_remove(players[name].hud)
 		end
 		if reason and reason.type == "punch" then
 			local hitter = reason.object


### PR DESCRIPTION
See description
How to test:
Consume medkit
Kill player in one hit

Tested, should work