### PR TITLE
Add kill assist

### DIFF
--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -462,16 +462,16 @@ minetest.register_on_punchplayer(function(player, hitter,
 		local hitters = {}
 
 		for a,b in pairs(pmeta:to_table()) do
-			if string.match(a, "hitter= ") then
+			if string.match(a, "hitter=") then
 				table.insert(hitter, pmeta[a])
 			end
 		end
 
 		if #hitters then
-			local dmg = pmeta:get_int("hitter= "..hname)
-			pmeta:set_int("hitter= "..hname, dmg + damage)
+			local dmg = pmeta:get_int("hitter="..hname)
+			pmeta:set_int("hitter="..hname, dmg + damage)
 		else
-			pmeta:set_int("hitter= "..hname, damage)
+			pmeta:set_int("hitter="..hname, damage)
 		end
 
 		local to = ctf.player(pname)

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -26,6 +26,7 @@ function ctf.team(name)
 		end
 	end
 end
+--Test commit
 
 function ctf.create_team(name, data)
 	ctf.log("team", "Creating team " .. name)

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -478,9 +478,13 @@ function ctf.reward_assists(victim, killer, reward)
 					if newReward < 1 then
 						newReward = 1
 					end
+					local colour = "0x00FFFF"
+					if name == killer then
+						colour = "0x00FF00"
+					end
 					_ = hud_score.new(name, {
 						name = "ctf_stats:kill_score",
-						color = "0x00FF00",
+						color = colour,
 						value = newReward
 					})
 				end

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -437,9 +437,9 @@ minetest.register_on_joinplayer(function(player)
 	end
 end)
 
-function ctf.clearAssists(playerName)
-	local player = minetest.get_player_by_name(playerName)
-	local pmeta = player:get_meta()
+function ctf.clear_assists(player)
+	local p = minetest.get_player_by_name(player)
+	local pmeta = p:get_meta()
 	local prefix = "hitter="
 	for name,damage in pairs(pmeta:to_table().fields) do
 		local subStringValue = string.sub(tostring(name), 1, #prefix+1)

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -474,7 +474,8 @@ function ctf.reward_assists(victim, killer, reward, is_suicide)
 		for name, damage in pairs(kill_assists[victim]["players"]) do
 			local playerExists = minetest.get_player_by_name(name)
 			if playerExists and name ~= victim then
-				local playerHP_max = ctf_classes.__classes[playerExists:get_meta():to_table().fields["ctf_classes:class"]].properties.max_hp-8
+				local victimClass = minetest.get_player_by_name(victim):get_meta():to_table().fields["ctf_classes:class"]
+				local playerHP_max = ctf_classes.__classes[victimClass].properties.max_hp-8
 				local standard = 0
 				local percentofhelp = damage / playerHP_max
 				if name ~= killer then

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -459,20 +459,20 @@ minetest.register_on_punchplayer(function(player, hitter,
 		local hname = hitter:get_player_name()
 		local pmeta = player:get_meta()
 
-		local hitters = {}
+		--local hitters = {}
+--
+		--for a,b in pairs(pmeta:to_table().fields) do
+		--	if string.match(a, "hitter=") then
+		--		table.insert(hitter, pmeta[a])
+		--	end
+		--end
 
-		for a,b in pairs(pmeta:to_table()) do
-			if string.match(a, "hitter=") then
-				table.insert(hitter, pmeta[a])
-			end
-		end
-
-		if #hitters then
-			local dmg = pmeta:get_int("hitter="..hname)
-			pmeta:set_int("hitter="..hname, dmg + damage)
-		else
-			pmeta:set_int("hitter="..hname, damage)
-		end
+		--if #hitters then
+		local dmg = pmeta:get_int("hitter="..hname) or 0
+		pmeta:set_int("hitter="..hname, dmg + damage)
+		--else
+		--	pmeta:set_int("hitter="..hname, damage)
+		--end
 
 		local to = ctf.player(pname)
 		local from = ctf.player(hname)

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -440,6 +440,9 @@ end)
 function ctf.clear_assists(player)
 	local p = minetest.get_player_by_name(player)
 	local pmeta = p:get_meta()
+	if pmeta:get_int("assists") == 0 then
+		return
+	end
 	local prefix = "hitter="
 	for name,damage in pairs(pmeta:to_table().fields) do
 		local subStringValue = string.sub(tostring(name), 1, #prefix+1)
@@ -447,6 +450,7 @@ function ctf.clear_assists(player)
 			pmeta:set_int(name, 0)
 		end
 	end
+	pmeta:set_int("assists", 0)
 end
 
 -- Disable friendly fire.
@@ -474,6 +478,7 @@ minetest.register_on_punchplayer(function(player, hitter,
 		local property = "hitter="..hname
 		local dmg = pmeta:get_int(property) or 0
 		pmeta:set_int(property, dmg + damage)
+		pmeta:set_int("assists", 1)
 
 		local to = ctf.player(pname)
 		local from = ctf.player(hname)

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -474,8 +474,13 @@ function ctf.reward_assists(victim, killer, reward, is_suicide)
 		for name, damage in pairs(kill_assists[victim]["players"]) do
 			local playerExists = minetest.get_player_by_name(name)
 			if playerExists and name ~= victim then
+				local hpClass = {
+					knight = 30,
+					shooter = 16,
+					medic = 20
+				}
 				local victimClass = minetest.get_player_by_name(victim):get_meta():to_table().fields["ctf_classes:class"]
-				local playerHP_max = ctf_classes.__classes[victimClass].properties.max_hp-8
+				local playerHP_max = (hpClass[victimClass] or hpClass.shooter)-8
 				local standard = 0
 				local percentofhelp = damage / playerHP_max
 				if name ~= killer then

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -437,6 +437,19 @@ minetest.register_on_joinplayer(function(player)
 	end
 end)
 
+function ctf.clearAssists(playerName)
+	local player = minetest.get_player_by_name(playerName)
+	local pmeta = player:get_meta()
+	local prefix = "hitter="
+	for name,damage in pairs(pmeta:to_table().fields) do
+		local subStringValue = string.sub(tostring(name), 1, #prefix+1)
+		if string.match(subStringValue, prefix) then
+			local pname = string.sub(name,#prefix+1, #name+1)
+			pmeta:set_int(name, 0)
+		end
+	end
+end
+
 -- Disable friendly fire.
 ctf.registered_on_killedplayer = {}
 function ctf.register_on_killedplayer(func)

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -474,7 +474,7 @@ function ctf.reward_assists(victim, killer, reward, is_suicide)
 		for name, damage in pairs(kill_assists[victim]["players"]) do
 			local playerExists = minetest.get_player_by_name(name)
 			if playerExists and name ~= victim then
-				local playerHP_max = ctf_respawn_delay.players[victim].old_max-8
+				local playerHP_max = ctf_classes.__classes[playerExists:get_meta():to_table().fields["ctf_classes:class"]].properties.max_hp-8
 				local standard = 0
 				local percentofhelp = damage / playerHP_max
 				if name ~= killer then

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -26,7 +26,6 @@ function ctf.team(name)
 		end
 	end
 end
---Test commit
 
 function ctf.create_team(name, data)
 	ctf.log("team", "Creating team " .. name)
@@ -458,6 +457,22 @@ minetest.register_on_punchplayer(function(player, hitter,
 	if player and hitter then
 		local pname = player:get_player_name()
 		local hname = hitter:get_player_name()
+		local pmeta = player:get_meta()
+
+		local hitters = {}
+
+		for a,b in pairs(pmeta:to_table()) do
+			if string.match(a, "hitter= ") then
+				table.insert(hitter, pmeta[a])
+			end
+		end
+
+		if #hitters then
+			local dmg = pmeta:get_int("hitter= "..hname)
+			pmeta:set_int("hitter= "..hname, dmg + damage)
+		else
+			pmeta:set_int("hitter= "..hname, damage)
+		end
 
 		local to = ctf.player(pname)
 		local from = ctf.player(hname)

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -459,20 +459,9 @@ minetest.register_on_punchplayer(function(player, hitter,
 		local hname = hitter:get_player_name()
 		local pmeta = player:get_meta()
 
-		--local hitters = {}
---
-		--for a,b in pairs(pmeta:to_table().fields) do
-		--	if string.match(a, "hitter=") then
-		--		table.insert(hitter, pmeta[a])
-		--	end
-		--end
-
-		--if #hitters then
-		local dmg = pmeta:get_int("hitter="..hname) or 0
-		pmeta:set_int("hitter="..hname, dmg + damage)
-		--else
-		--	pmeta:set_int("hitter="..hname, damage)
-		--end
+		local property = "hitter="..hname
+		local dmg = pmeta:get_int(property) or 0
+		pmeta:set_int(property, dmg + damage)
 
 		local to = ctf.player(pname)
 		local from = ctf.player(hname)

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -444,7 +444,6 @@ function ctf.clearAssists(playerName)
 	for name,damage in pairs(pmeta:to_table().fields) do
 		local subStringValue = string.sub(tostring(name), 1, #prefix+1)
 		if string.match(subStringValue, prefix) then
-			local pname = string.sub(name,#prefix+1, #name+1)
 			pmeta:set_int(name, 0)
 		end
 	end

--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -510,7 +510,6 @@ minetest.register_on_punchplayer(function(player, hitter,
 	if player and hitter then
 		local pname = player:get_player_name()
 		local hname = hitter:get_player_name()
-		local pmeta = player:get_meta()
 
 		local to = ctf.player(pname)
 		local from = ctf.player(hname)

--- a/mods/ctf/ctf_bandages/init.lua
+++ b/mods/ctf/ctf_bandages/init.lua
@@ -24,7 +24,9 @@ minetest.register_craftitem("ctf_bandages:bandage", {
 			local limit = ctf_bandages.heal_percent *
 				object:get_properties().hp_max
 			if hp > 0 and hp < limit then
-				hp = hp + math.random(3,4)
+				local hp_add = math.random(3,4)
+				ctf.add_heal_assist(pname, hp_add)
+				hp = hp + hp_add
 				if hp > limit then
 					hp = limit
 				end

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -428,18 +428,12 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 		main.kills  = main.kills  + 1
 		main.score  = main.score  + reward
 		match.kills = match.kills + 1
-		match.score = match.score + reward
 		match.kills_since_death = match.kills_since_death + 1
 		_needs_save = true
 
 		reward = math.floor(reward * 100) / 100
 
 		ctf.reward_assists(victim, killer, reward)
-		--hud_score.new(killer, {
-		--	name = "ctf_stats:kill_score",
-		--	color = "0x00FF00",
-		--	value = reward
-		--})
 	end
 end)
 

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -461,9 +461,13 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 		if hitLength > 0 then
 			for name,damage in pairs(hitters) do
 				local playerExists = minetest.get_player_by_name(name)
-				if name ~= killer and playerExists then
+				if playerExists then
 					local playerHP_max = playerExists:get_properties().hp_max
-					if not (tonumber(damage) > playerHP_max*0.5) then
+					local ratiolimit = 0
+					if name ~= killer then
+						ratiolimit = playerHP_max * 0.5
+					end
+					if not (tonumber(damage) > ratiolimit) then
 						local percentofhelp = math.min(damage / playerHP_max, 0.75)
 						local _, pmatch = ctf_stats.player(name)
 						local newReward = math.floor((reward * percentofhelp)*100)/100

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -444,17 +444,21 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 
 		local pmeta = minetest.get_player_by_name(victim):get_meta()
 
-		for name,damage in pairs(pmeta:to_table()) do
-			if string.match(name, "hitter= ") then
-				table.insert(hitters, {name=damage})
+		for name,damage in pairs(pmeta:to_table().fields) do
+			local subStringValue = string.sub(tostring(name), 1, #"hitter="+1)
+			if string.match(subStringValue, "hitter=") then
+				local pname = string.sub(name,#"hitter="+1, #name+1)
+				--table.insert(hitters, {pname=damage})
+				hitters[pname] = damage
 			end
 		end
+		--print(dump(hitters))
 		if #hitters then
 			for name,damage in pairs(hitters) do
-				local percentofhelp = pmeta:get_int(name) / victim:get_properties().hp_max
-				local pname = name:sub(0,#"hitter= ")
+				local percentofhelp = pmeta:get_int(name) / minetest.get_player_by_name(victim):get_properties().hp_max
+				local pname = name
+				print("-"..pname.."-")
 				local pmain, pmatch = ctf_stats.player(pname)
-
 				local newReward = math.floor(reward * percentofhelp)
 
 				match.score = match.score + newReward

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -454,23 +454,18 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 			end
 		end
 
-		--there is probably a better way to get the length
 		local hitLength = 0
 		for a,b in pairs(hitters) do
 			hitLength = hitLength + 1
 		end
 
-		print(#hitters)
-		print(dump(hitters))
-
 		if hitLength > 0 then
-			local playerExists = false
 			for name,damage in pairs(hitters) do
-				playerExists = minetest.get_player_by_name(name)
+				local playerExists = minetest.get_player_by_name(name)
 				if name ~= killer and playerExists then
 					local playerHP_max = playerExists:get_properties().hp_max
 					local percentofhelp = damage / playerHP_max
-					local pmain, pmatch = ctf_stats.player(name)
+					local _, pmatch = ctf_stats.player(name)
 					local newReward = math.floor((reward * percentofhelp)*100)/100
 					pmatch.score = pmatch.score + newReward
 

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -448,25 +448,41 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 			local subStringValue = string.sub(tostring(name), 1, #"hitter="+1)
 			if string.match(subStringValue, "hitter=") then
 				local pname = string.sub(name,#"hitter="+1, #name+1)
-				--table.insert(hitters, {pname=damage})
 				hitters[pname] = damage
+				pmeta:set_int(name, 0)
 			end
 		end
-		--print(dump(hitters))
-		if #hitters then
+		local hitLength = 0--#hitters
+		for a,b in pairs(hitters) do
+			hitLength = hitLength + 1
+		end
+		print(hitLength)
+		print(dump(hitters))
+		if hitLength > 0 then
 			for name,damage in pairs(hitters) do
-				local percentofhelp = pmeta:get_int(name) / minetest.get_player_by_name(victim):get_properties().hp_max
+				print("name: "..name)
+				--local percentofhelp = pmeta:get_int(name) / minetest.get_player_by_name(victim):get_properties().hp_max
+				local playerHP_max = minetest.get_player_by_name(victim):get_properties().hp_max
+				local percentofhelp = damage / playerHP_max
+				print("percentofhelp: "..percentofhelp)
 				local pname = name
-				print("-"..pname.."-")
 				local pmain, pmatch = ctf_stats.player(pname)
+				print("pmain: "..dump(pmain))
+				print("pmatch: "..dump(pmatch))
 				local newReward = math.floor(reward * percentofhelp)
+				print("newReward: "..newReward)
 
 				match.score = match.score + newReward
 
+				print(dump(name) .. dump(damage))
+
+				if newReward > 0 then
+					newReward = 1
+				end
 				hud_score.new(pname, {
 					name = "ctf_stats:kill_score",
 					color = "0x00FF00",
-					value = reward
+					value = newReward
 				})
 			end
 		end

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -418,23 +418,9 @@ local function calculateKillReward(victim, killer, toolcaps)
 end
 
 ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
-	-- Suicide is not encouraged here at CTF
-	if victim == killer then
-		return
-	end
-	local main, match = ctf_stats.player(killer)
-	if main and match then
-		local reward = calculateKillReward(victim, killer, toolcaps)
-		main.kills  = main.kills  + 1
-		main.score  = main.score  + reward
-		match.kills = match.kills + 1
-		match.kills_since_death = match.kills_since_death + 1
-		_needs_save = true
-
-		reward = math.floor(reward * 100) / 100
-
-		ctf.reward_assists(victim, killer, reward)
-	end
+	local reward = calculateKillReward(victim, killer, toolcaps)
+	reward = math.floor(reward * 100) / 100
+	ctf.reward_assists(victim, killer, reward, (victim == killer))
 end)
 
 minetest.register_on_dieplayer(function(player)

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -464,7 +464,7 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 				if name ~= killer and playerExists then
 					local playerHP_max = playerExists:get_properties().hp_max
 					if not (tonumber(damage) > playerHP_max*0.5) then
-						local percentofhelp = damage / playerHP_max
+						local percentofhelp = math.min(damage / playerHP_max, 0.75)
 						local _, pmatch = ctf_stats.player(name)
 						local newReward = math.floor((reward * percentofhelp)*100)/100
 						pmatch.score = pmatch.score + newReward

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -434,57 +434,12 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 
 		reward = math.floor(reward * 100) / 100
 
-		hud_score.new(killer, {
-			name = "ctf_stats:kill_score",
-			color = "0x00FF00",
-			value = reward
-		})
-
-		local hitters = {}
-		local pmeta = minetest.get_player_by_name(victim):get_meta()
-		local prefix = "hitter="
-
-		for name,damage in pairs(pmeta:to_table().fields) do
-			local subStringValue = string.sub(tostring(name), 1, #prefix+1)
-			if string.match(subStringValue, prefix) then
-				local pname = string.sub(name,#prefix+1, #name+1)
-				hitters[pname] = damage
-				pmeta:set_int(name, 0)
-			end
-		end
-
-		local hitLength = 0
-		for a,b in pairs(hitters) do
-			hitLength = hitLength + 1
-		end
-
-		if hitLength > 0 then
-			for name,damage in pairs(hitters) do
-				local playerExists = minetest.get_player_by_name(name)
-				if playerExists then
-					local playerHP_max = playerExists:get_properties().hp_max
-					local ratiolimit = 0
-					if name ~= killer then
-						ratiolimit = playerHP_max * 0.5
-					end
-					if not (tonumber(damage) > ratiolimit) then
-						local percentofhelp = math.min(damage / playerHP_max, 0.75)
-						local _, pmatch = ctf_stats.player(name)
-						local newReward = math.floor((reward * percentofhelp)*100)/100
-						pmatch.score = pmatch.score + newReward
-
-						if newReward <= 1 then
-							newReward = 1
-						end
-						hud_score.new(name, {
-							name = "ctf_stats:kill_score",
-							color = "0x00FF00",
-							value = newReward
-						})
-					end
-				end
-			end
-		end
+		ctf.reward_assists(victim, killer, reward)
+		--hud_score.new(killer, {
+		--	name = "ctf_stats:kill_score",
+		--	color = "0x00FF00",
+		--	value = reward
+		--})
 	end
 end)
 

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -439,6 +439,33 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 			color = "0x00FF00",
 			value = reward
 		})
+
+		local hitters = {}
+
+		local pmeta = minetest.get_player_by_name(victim):get_meta()
+
+		for name,damage in pairs(pmeta:to_table()) do
+			if string.match(name, "hitter= ") then
+				table.insert(hitters, {name=damage})
+			end
+		end
+		if #hitters then
+			for name,damage in pairs(hitters) do
+				local percentofhelp = pmeta:get_int(name) / victim:get_properties().hp_max
+				local pname = name:sub(0,#"hitter= ")
+				local pmain, pmatch = ctf_stats.player(pname)
+
+				local newReward = math.floor(reward * percentofhelp)
+
+				match.score = match.score + newReward
+
+				hud_score.new(pname, {
+					name = "ctf_stats:kill_score",
+					color = "0x00FF00",
+					value = reward
+				})
+			end
+		end
 	end
 end)
 

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -441,7 +441,6 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 		})
 
 		local hitters = {}
-
 		local pmeta = minetest.get_player_by_name(victim):get_meta()
 		local prefix = "hitter="
 
@@ -464,19 +463,21 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 				local playerExists = minetest.get_player_by_name(name)
 				if name ~= killer and playerExists then
 					local playerHP_max = playerExists:get_properties().hp_max
-					local percentofhelp = damage / playerHP_max
-					local _, pmatch = ctf_stats.player(name)
-					local newReward = math.floor((reward * percentofhelp)*100)/100
-					pmatch.score = pmatch.score + newReward
+					if not (tonumber(damage) > playerHP_max*0.5) then
+						local percentofhelp = damage / playerHP_max
+						local _, pmatch = ctf_stats.player(name)
+						local newReward = math.floor((reward * percentofhelp)*100)/100
+						pmatch.score = pmatch.score + newReward
 
-					if newReward <= 1 then
-						newReward = 1
+						if newReward <= 1 then
+							newReward = 1
+						end
+						hud_score.new(name, {
+							name = "ctf_stats:kill_score",
+							color = "0x00FF00",
+							value = newReward
+						})
 					end
-					hud_score.new(name, {
-						name = "ctf_stats:kill_score",
-						color = "0x00FF00",
-						value = newReward
-					})
 				end
 			end
 		end

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -443,47 +443,46 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 		local hitters = {}
 
 		local pmeta = minetest.get_player_by_name(victim):get_meta()
+		local prefix = "hitter="
 
 		for name,damage in pairs(pmeta:to_table().fields) do
-			local subStringValue = string.sub(tostring(name), 1, #"hitter="+1)
-			if string.match(subStringValue, "hitter=") then
-				local pname = string.sub(name,#"hitter="+1, #name+1)
+			local subStringValue = string.sub(tostring(name), 1, #prefix+1)
+			if string.match(subStringValue, prefix) then
+				local pname = string.sub(name,#prefix+1, #name+1)
 				hitters[pname] = damage
 				pmeta:set_int(name, 0)
 			end
 		end
-		local hitLength = 0--#hitters
+
+		--there is probably a better way to get the length
+		local hitLength = 0
 		for a,b in pairs(hitters) do
 			hitLength = hitLength + 1
 		end
-		print(hitLength)
+
+		print(#hitters)
 		print(dump(hitters))
+
 		if hitLength > 0 then
+			local playerExists = false
 			for name,damage in pairs(hitters) do
-				print("name: "..name)
-				--local percentofhelp = pmeta:get_int(name) / minetest.get_player_by_name(victim):get_properties().hp_max
-				local playerHP_max = minetest.get_player_by_name(victim):get_properties().hp_max
-				local percentofhelp = damage / playerHP_max
-				print("percentofhelp: "..percentofhelp)
-				local pname = name
-				local pmain, pmatch = ctf_stats.player(pname)
-				print("pmain: "..dump(pmain))
-				print("pmatch: "..dump(pmatch))
-				local newReward = math.floor(reward * percentofhelp)
-				print("newReward: "..newReward)
+				playerExists = minetest.get_player_by_name(name)
+				if name ~= killer and playerExists then
+					local playerHP_max = playerExists:get_properties().hp_max
+					local percentofhelp = damage / playerHP_max
+					local pmain, pmatch = ctf_stats.player(name)
+					local newReward = math.floor((reward * percentofhelp)*100)/100
+					pmatch.score = pmatch.score + newReward
 
-				match.score = match.score + newReward
-
-				print(dump(name) .. dump(damage))
-
-				if newReward > 0 then
-					newReward = 1
+					if newReward <= 1 then
+						newReward = 1
+					end
+					hud_score.new(name, {
+						name = "ctf_stats:kill_score",
+						color = "0x00FF00",
+						value = newReward
+					})
 				end
-				hud_score.new(pname, {
-					name = "ctf_stats:kill_score",
-					color = "0x00FF00",
-					value = newReward
-				})
 			end
 		end
 	end

--- a/mods/pvp/anticoward/init.lua
+++ b/mods/pvp/anticoward/init.lua
@@ -153,6 +153,7 @@ minetest.register_globalstep(function(dtime)
 
 				if player then
 					player:hud_remove(potential_cowards[k].hud or 0)
+					ctf.clearAssists(k)
 				end
 
 				potential_cowards[k] = nil

--- a/mods/pvp/anticoward/init.lua
+++ b/mods/pvp/anticoward/init.lua
@@ -153,7 +153,7 @@ minetest.register_globalstep(function(dtime)
 
 				if player then
 					player:hud_remove(potential_cowards[k].hud or 0)
-					ctf.clearAssists(k)
+					ctf.clear_assists(k)
 				end
 
 				potential_cowards[k] = nil

--- a/mods/pvp/hpregen/init.lua
+++ b/mods/pvp/hpregen/init.lua
@@ -19,6 +19,7 @@ local function regen_all()
 				ctf.clear_assists(player:get_player_name())
 			end
 			if oldhp ~= newhp then
+				ctf.add_heal_assist(player:get_player_name(), hpregen.amount)
 				player:set_hp(newhp)
 			end
 		end

--- a/mods/pvp/hpregen/init.lua
+++ b/mods/pvp/hpregen/init.lua
@@ -16,6 +16,7 @@ local function regen_all()
 			local newhp = oldhp + hpregen.amount
 			if newhp > player:get_properties().hp_max then
 				newhp = player:get_properties().hp_max
+				ctf.clear_assists(player:get_player_name())
 			end
 			if oldhp ~= newhp then
 				player:set_hp(newhp)

--- a/mods/pvp/medkits/init.lua
+++ b/mods/pvp/medkits/init.lua
@@ -117,6 +117,7 @@ minetest.register_globalstep(function(dtime)
 			if pstat then
 				local hp = player:get_hp()
 				if hp < pstat.regen_max then
+					ctf.add_heal_assist(name, regen_step)
 					player:set_hp(math.min(hp + regen_step, pstat.regen_max))
 				else
 					stop_healing(player)


### PR DESCRIPTION
Add's a feature that gives points to players who do more than 50% damage and don't get the kill.