### PR TITLE
Shorten marker message

### DIFF
--- a/mods/ctf/ctf_marker/init.lua
+++ b/mods/ctf/ctf_marker/init.lua
@@ -55,7 +55,7 @@ function ctf_marker.add_marker(name, tname, pos, str)
 		minetest.log("action", name .. " placed a marker at " ..
 				minetest.pos_to_string(pos) .. ": '" .. str .. "'")
 		minetest.chat_send_player(pname,
-				msg("Player " .. name .. " placed a marker!"))
+				msg("* " .. name .. " placed a marker!"))
 	end
 end
 


### PR DESCRIPTION
I was first thinking of just removing the "Player ..." from the message but similar to what `/me` does markers should be displayed like that too IMO.