### PR TITLE
Edit the marker name placed with knight sword

### DIFF
--- a/mods/ctf/ctf_classes/melee.lua
+++ b/mods/ctf/ctf_classes/melee.lua
@@ -105,7 +105,7 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		sword_special_timer[pname] = 20
 		sword_special_timer_func(pname, 20)
 
-		minetest.registered_chatcommands["m"].func(pname, "Marked with "..pname.."'s sword")
+		minetest.registered_chatcommands["m"].func(pname, ""..pname.."'s sword marker")
 	end,
 	on_secondary_use = function(itemstack, user, pointed_thing)
 		if pointed_thing then

--- a/mods/ctf/ctf_classes/melee.lua
+++ b/mods/ctf/ctf_classes/melee.lua
@@ -105,7 +105,7 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		sword_special_timer[pname] = 20
 		sword_special_timer_func(pname, 20)
 
-		minetest.registered_chatcommands["m"].func(pname, ""..pname.."'s sword marker")
+		minetest.registered_chatcommands["m"].func(pname)
 	end,
 	on_secondary_use = function(itemstack, user, pointed_thing)
 		if pointed_thing then


### PR DESCRIPTION
For example: DiamondPlane's sword marker
JostP suggested changes so it will be now:
DiamondPlane's marker like when you just type /m