### PR TITLE
Add sound when walking on wool

### DIFF
--- a/mods/mtg/wool/init.lua
+++ b/mods/mtg/wool/init.lua
@@ -29,7 +29,7 @@ for i = 1, #dyes do
 		is_ground_content = false,
 		groups = {snappy = 2, choppy = 2, oddly_breakable_by_hand = 3,
 				flammable = 3, wool = 1},
-		sounds = default.node_sound_defaults(),
+		sounds = default.node_sound_dirt_defaults(),
 	})
 end
 


### PR DESCRIPTION
Currently there is no sound when walking on wool. This PR makes that when you walk on wool, there is the same sound as when walking on dirt. Sound played when digging wool isn't changed by this PR, it is different than dirt's digging sound.

Tested, works.