### PR TITLE
Restore register_on_killedplayer callback in ctf_stats

### DIFF
--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -417,6 +417,20 @@ function ctf_stats.calculateKillReward(victim, killer, toolcaps)
 	return reward
 end
 
+ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
+	-- Suicide is not encouraged here at CTF
+	if victim == killer then
+		return
+	end
+	local main, match = ctf_stats.player(killer)
+	if main and match then
+		main.kills  = main.kills  + 1
+		match.kills = match.kills + 1
+		match.kills_since_death = match.kills_since_death + 1
+		_needs_save = true
+	end
+end)
+
 minetest.register_on_dieplayer(function(player)
 	local main, match = ctf_stats.player(player:get_player_name())
 

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -417,7 +417,7 @@ function ctf_stats.calculateKillReward(victim, killer, toolcaps)
 	return reward
 end
 
-ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
+ctf.register_on_killedplayer(function(victim, killer)
 	-- Suicide is not encouraged here at CTF
 	if victim == killer then
 		return

--- a/mods/pvp/kill_assist/init.lua
+++ b/mods/pvp/kill_assist/init.lua
@@ -48,9 +48,6 @@ function kill_assist.reward_assists(victim, killer, reward)
 
 			if name == killer then
 				color = "0x00FF00"
-				main.kills = main.kills + 1
-				match.kills = match.kills + 1
-				match.kills_since_death = match.kills_since_death + 1
 			end
 
 			hud_score.new(name, {


### PR DESCRIPTION
kill assist system shouldn't affect player kill stats