### PR TITLE
Updated antisabotage to work with sniper rifles

### DIFF
--- a/mods/ctf/ctf_classes/medic.lua
+++ b/mods/ctf/ctf_classes/medic.lua
@@ -155,7 +155,7 @@ local function remove_pillar(pos, pname)
 
 		if minetest.get_modpath("antisabotage") then
 			-- Fix paxel being capable of mining blocks under teammates
-			if antisabotage.is_sabotage(pos, minetest.get_node(pos), player) then return end
+			if antisabotage.is_sabotage(pos, minetest.get_node(pos), player, true) then return end
 		end
 
 		minetest.dig_node(pos)

--- a/mods/pvp/antisabotage/init.lua
+++ b/mods/pvp/antisabotage/init.lua
@@ -1,4 +1,4 @@
--- Code by Apelta. Mutelated by Lone_Wolf. Mutelated again by Apelta.
+-- Code by Apelta. Mutelated by Lone_Wolf. Mutelated again by Apelta. Slightly modified by oneplustwo.
 antisabotage = {}
 
 function antisabotage.is_sabotage(pos, oldnode, digger, show_msg) -- used for paxel

--- a/mods/pvp/antisabotage/init.lua
+++ b/mods/pvp/antisabotage/init.lua
@@ -1,7 +1,7 @@
 -- Code by Apelta. Mutelated by Lone_Wolf. Mutelated again by Apelta.
 antisabotage = {}
 
-function antisabotage.is_sabotage(pos, oldnode, digger) -- used for paxel
+function antisabotage.is_sabotage(pos, oldnode, digger, show_msg) -- used for paxel
 	local dname = digger:get_player_name()
 
 	for _, player in pairs(minetest.get_connected_players()) do
@@ -17,8 +17,8 @@ function antisabotage.is_sabotage(pos, oldnode, digger) -- used for paxel
 				for _, item in pairs(minetest.get_node_drops(oldnode)) do
 					digger:get_inventory():remove_item("main", ItemStack(item))
 				end
-
-				minetest.chat_send_player(dname, "You can't mine blocks under your teammates!")
+				
+				if show_msg then minetest.chat_send_player(dname, "You can't mine blocks under your teammates!") end
 				return true
 			end
 		end
@@ -28,5 +28,5 @@ end
 minetest.register_on_dignode(function(pos, oldnode, digger)
 	if not digger:is_player() then return end
 
-	antisabotage.is_sabotage(pos, oldnode, digger)
+	antisabotage.is_sabotage(pos, oldnode, digger, true)
 end)

--- a/mods/pvp/antisabotage/init.lua
+++ b/mods/pvp/antisabotage/init.lua
@@ -17,7 +17,7 @@ function antisabotage.is_sabotage(pos, oldnode, digger, show_msg) -- used for pa
 				for _, item in pairs(minetest.get_node_drops(oldnode)) do
 					digger:get_inventory():remove_item("main", ItemStack(item))
 				end
-				
+
 				if show_msg then minetest.chat_send_player(dname, "You can't mine blocks under your teammates!") end
 				return true
 			end

--- a/mods/pvp/shooter_tweaks/init.lua
+++ b/mods/pvp/shooter_tweaks/init.lua
@@ -167,7 +167,7 @@ shooter.punch_node = function(pos, spec)
 	end
 
 	if antisabotage.is_sabotage(pos, minetest.get_node(pos), spec.user, false) then
-		minetest.chat_send_player(name,
+		minetest.chat_send_player(spec.user:get_player_name(),
 			"You can't shoot blocks under your teammates!")
 	end
 

--- a/mods/pvp/sniper_rifles/init.lua
+++ b/mods/pvp/sniper_rifles/init.lua
@@ -157,7 +157,7 @@ local old_is_protected = minetest.is_protected
 local r = ctf.setting("flag.nobuild_radius") + 5
 local rs = r * r
 function minetest.is_protected(pos, name, info, ...)
-	if antisabotage.is_sabotage(pos, minetest.get_node(pos), minetest.get_player_by_name(name)) then
+	if antisabotage.is_sabotage(pos, minetest.get_node(pos), minetest.get_player_by_name(name), false) then
 		minetest.chat_send_player(name,
 			"You can't shoot blocks under your teammates!")
 		return true

--- a/mods/pvp/sniper_rifles/init.lua
+++ b/mods/pvp/sniper_rifles/init.lua
@@ -163,7 +163,6 @@ function minetest.is_protected(pos, name, info, ...)
 		return true
 	end
 
-	end
 	if r <= 0 or rs == 0 or not info or not info.is_gun then
 		return old_is_protected(pos, name, info, ...)
 	end

--- a/mods/pvp/sniper_rifles/init.lua
+++ b/mods/pvp/sniper_rifles/init.lua
@@ -157,6 +157,13 @@ local old_is_protected = minetest.is_protected
 local r = ctf.setting("flag.nobuild_radius") + 5
 local rs = r * r
 function minetest.is_protected(pos, name, info, ...)
+	if antisabotage.is_sabotage(pos, minetest.get_node(pos), minetest.get_player_by_name(name)) then
+		minetest.chat_send_player(name,
+			"You can't shoot blocks under your teammates!")
+		return true
+	end
+
+	end
 	if r <= 0 or rs == 0 or not info or not info.is_gun then
 		return old_is_protected(pos, name, info, ...)
 	end

--- a/mods/pvp/sniper_rifles/mod.conf
+++ b/mods/pvp/sniper_rifles/mod.conf
@@ -1,3 +1,3 @@
 name = sniper_rifles
-depends = shooter, physics, ctf, ctf_flag
+depends = shooter, physics, ctf, ctf_flag, antisabotage
 description = Sniper rifle API (depends on shooter) along with couple of sniper rifles.


### PR DESCRIPTION
Antisabotage now applies to sniper rifles: if you shoot a node under your teammate, it does not break.