### PR TITLE
Don't count kill assist on build time or player immunity

### DIFF
--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -446,12 +446,20 @@ function ctf.register_on_killedplayer(func)
 	table.insert(ctf.registered_on_killedplayer, func)
 end
 
-ctf.registered_on_punchplayer = {}
-function ctf.register_on_punchplayer(func)
+ctf.registered_can_attack = {}
+function ctf.register_can_attack(func)
 	if ctf._mt_loaded then
 		error("You can't register callbacks at game time!")
 	end
-	table.insert(ctf.registered_on_punchplayer, func)
+	table.insert(ctf.registered_can_attack, func)
+end
+
+ctf.registered_on_attack = {}
+function ctf.register_on_attack(func)
+	if ctf._mt_loaded then
+		error("You can't register callbacks at game time!")
+	end
+	table.insert(ctf.registered_on_attack, func)
 end
 
 local dead_players = {}
@@ -482,6 +490,15 @@ minetest.register_on_punchplayer(function(player, hitter,
 			end
 		end
 
+		for i = 1, #ctf.register_can_attack do
+			if ctf.registered_can_attack[i](
+				player, hitter, time_from_last_punch,
+				tool_capabilities, dir, damage, ...
+			) == false then
+				return false
+			end
+		end
+
 		local hp = player:get_hp()
 		if hp == 0 then
 			return false
@@ -497,8 +514,8 @@ minetest.register_on_punchplayer(function(player, hitter,
 			return false
 		end
 
-		for i = 1, #ctf.registered_on_punchplayer do
-			ctf.registered_on_punchplayer[i](
+		for i = 1, #ctf.registered_on_attack do
+			ctf.registered_on_attack[i](
 				player, hitter, time_from_last_punch,
 				tool_capabilities, dir, damage, ...
 			)

--- a/mods/ctf/ctf_match/buildtime.lua
+++ b/mods/ctf/ctf_match/buildtime.lua
@@ -62,12 +62,12 @@ minetest.register_globalstep(function(delta)
 	end
 end)
 
-minetest.register_on_punchplayer(function(_, hitter)
+ctf.register_can_attack(function(_, hitter)
 	if ctf_match.is_in_build_time() then
 		if hitter:is_player() then
 			minetest.chat_send_player(hitter:get_player_name(), "Match hasn't started yet!")
 		end
-		return true
+		return false
 	end
 end)
 

--- a/mods/ctf/ctf_respawn_immunity/init.lua
+++ b/mods/ctf/ctf_respawn_immunity/init.lua
@@ -34,30 +34,26 @@ function ctf_respawn_immunity.update_effects(player)
 	-- end
 end
 
-minetest.register_on_punchplayer(function(player, hitter,
+ctf.register_can_attack(function(player, hitter,
 		time_from_last_punch, tool_capabilities, dir, damage)
 	if not player or not hitter then
-		return false
+		return
 	end
 
 	local pname = player:get_player_name()
 	local hname = hitter:get_player_name()
-	local pteam = ctf.player(pname).team
-	local hteam = ctf.player(hname).team
 
-	if pteam ~= hteam then
-		if player and ctf_respawn_immunity.is_immune(player) then
-			minetest.chat_send_player(hname, minetest.colorize("#EE8822", pname ..
-					" just respawned or joined," .. " and is immune to attacks!"))
-			return true
-		end
+	if ctf_respawn_immunity.is_immune(player) then
+		minetest.chat_send_player(hname, minetest.colorize("#EE8822", pname ..
+				" just respawned or joined," .. " and is immune to attacks!"))
+		return false
+	end
 
-		if hitter and ctf_respawn_immunity.is_immune(hitter) then
-			minetest.chat_send_player(hname, minetest.colorize("#FF8C00",
-					"Your immunity has ended because you attacked a player"))
-			immune_players[hname] = nil
-			ctf_respawn_immunity.update_effects(hitter)
-		end
+	if ctf_respawn_immunity.is_immune(hitter) then
+		minetest.chat_send_player(hname, minetest.colorize("#FF8C00",
+				"Your immunity has ended because you attacked a player"))
+		immune_players[hname] = nil
+		ctf_respawn_immunity.update_effects(hitter)
 	end
 end)
 

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -417,6 +417,20 @@ function ctf_stats.calculateKillReward(victim, killer, toolcaps)
 	return reward
 end
 
+ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
+	-- Suicide is not encouraged here at CTF
+	if victim == killer then
+		return
+	end
+	local main, match = ctf_stats.player(killer)
+	if main and match then
+		main.kills  = main.kills  + 1
+		match.kills = match.kills + 1
+		match.kills_since_death = match.kills_since_death + 1
+		_needs_save = true
+	end
+end)
+
 minetest.register_on_dieplayer(function(player)
 	local main, match = ctf_stats.player(player:get_player_name())
 

--- a/mods/ctf/ctf_stats/init.lua
+++ b/mods/ctf/ctf_stats/init.lua
@@ -417,7 +417,7 @@ function ctf_stats.calculateKillReward(victim, killer, toolcaps)
 	return reward
 end
 
-ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
+ctf.register_on_killedplayer(function(victim, killer)
 	-- Suicide is not encouraged here at CTF
 	if victim == killer then
 		return

--- a/mods/pvp/anticoward/init.lua
+++ b/mods/pvp/anticoward/init.lua
@@ -9,23 +9,11 @@ local COMBATLOG_SCORE_PENALTY = 10
 --- Make suicides and combat logs award last puncher with kill
 --
 
-minetest.register_on_punchplayer(function(player, hitter,
+ctf.register_on_attack(function(player, hitter,
 		time_from_last_punch, tool_capabilities, dir, damage)
 	if player and hitter then
-		if ctf_respawn_immunity.is_immune(player) or ctf_match.is_in_build_time() then
-			return
-		end
-
 		local pname = player:get_player_name()
 		local hname = hitter:get_player_name()
-
-		local to = ctf.player(pname)
-		local from = ctf.player(hname)
-
-		if to.team == from.team and to.team ~= "" and
-				to.team ~= nil and to.name ~= from.name then
-			return
-		end
 
 		local hp = player:get_hp() - damage
 		if hp <= 0 then

--- a/mods/pvp/kill_assist/init.lua
+++ b/mods/pvp/kill_assist/init.lua
@@ -75,7 +75,7 @@ ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
 	kill_assist.reward_assists(victim, killer, reward)
 end)
 
-ctf.register_on_punchplayer(function(player, hitter, _, _, _, damage)
+ctf.register_on_attack(function(player, hitter, _, _, _, damage)
 	kill_assist.add_assist(player:get_player_name(), hitter:get_player_name(), damage)
 end)
 

--- a/mods/pvp/kill_assist/init.lua
+++ b/mods/pvp/kill_assist/init.lua
@@ -48,9 +48,6 @@ function kill_assist.reward_assists(victim, killer, reward)
 
 			if name == killer then
 				color = "0x00FF00"
-				main.kills = main.kills + 1
-				match.kills = match.kills + 1
-				match.kills_since_death = match.kills_since_death + 1
 			end
 
 			hud_score.new(name, {


### PR DESCRIPTION
Fix https://github.com/MT-CTF/capturetheflag/issues/793
Introduce ctf.register_can_attack callbacks that can stop any ctf related attack logic.