### PR TITLE
Limit node placement

### DIFF
--- a/mods/mtg/doors/init.lua
+++ b/mods/mtg/doors/init.lua
@@ -354,14 +354,20 @@ function doors.register(name, def)
 				meta:set_string("owner_team", tname)
 			end
 
+			local copy = table.copy
+			local newnode = minetest.get_node(pos)
+			for _, on_placenode in pairs(minetest.registered_on_placenodes) do
+				if on_placenode(copy(pos), copy(newnode), placer, copy(node), ItemStack(itemstack), copy(pointed_thing)) then
+					return itemstack
+				end
+			end
 			if not (creative and creative.is_enabled_for and creative.is_enabled_for(pn)) then
 				itemstack:take_item()
 			end
 
 			minetest.sound_play(def.sounds.place, {pos = pos})
 
-			on_place_node(pos, minetest.get_node(pos),
-				placer, node, itemstack, pointed_thing)
+			on_place_node(pos, newnode, placer, node, itemstack, pointed_thing)
 
 			return itemstack
 		end

--- a/mods/pvp/place_limit/License.txt
+++ b/mods/pvp/place_limit/License.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2021  appgurueu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mods/pvp/place_limit/Readme.md
+++ b/mods/pvp/place_limit/Readme.md
@@ -1,0 +1,8 @@
+# `place_limit`
+
+Fixes two things related to node placement:
+
+* Ratelimits node placement
+* Disallows building to non-pointable nodes (anticheat + race condition fix)
+
+Licensed under the MIT license, written by appgurueu.

--- a/mods/pvp/place_limit/init.lua
+++ b/mods/pvp/place_limit/init.lua
@@ -1,0 +1,20 @@
+local last_placement = {}
+
+minetest.register_on_joinplayer(function(player)
+	-- player has to wait after join before they can place a node
+	last_placement[player:get_player_name()] = minetest.get_us_time()
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	last_placement[player:get_player_name()] = nil
+end)
+
+minetest.register_on_placenode(function(pos, _newnode, placer, oldnode, _itemstack, _pointed_thing)
+	local name = placer:get_player_name()
+	local time = minetest.get_us_time()
+	if (time - last_placement[name]) / 1e6 < 0.2 then
+		minetest.set_node(pos, oldnode)
+		return true
+	end
+	last_placement[name] = time
+end)

--- a/mods/pvp/place_limit/init.lua
+++ b/mods/pvp/place_limit/init.lua
@@ -1,20 +1,53 @@
-local last_placement = {}
+-- Licensed under the MIT license, written by appgurueu.
+local players = {}
+local blocks_per_second = 5
+local resend_chat_message_seconds = 10
 
 minetest.register_on_joinplayer(function(player)
 	-- player has to wait after join before they can place a node
-	last_placement[player:get_player_name()] = minetest.get_us_time()
+	players[player:get_player_name()] = {
+		last_placement = minetest.get_us_time(),
+		last_chat_message_sent = -math.huge
+	}
 end)
+
+local chat_send_player = minetest.chat_send_player
+function minetest.chat_send_player(name, message)
+	if players[name] then
+		players[name].last_chat_message_sent = -math.huge
+	end
+	return chat_send_player(name, message)
+end
+
+local chat_send_all = minetest.chat_send_all
+function minetest.chat_send_all(message)
+	for _, playerdata in pairs(players) do
+		playerdata.last_chat_message_sent = -math.huge
+	end
+	return chat_send_all(message)
+end
 
 minetest.register_on_leaveplayer(function(player)
-	last_placement[player:get_player_name()] = nil
+	players[player:get_player_name()] = nil
 end)
 
-minetest.register_on_placenode(function(pos, _newnode, placer, oldnode, _itemstack, _pointed_thing)
-	local name = placer:get_player_name()
-	local time = minetest.get_us_time()
-	if (time - last_placement[name]) / 1e6 < 0.2 then
+minetest.register_on_placenode(function(pos, _newnode, placer, oldnode, _itemstack, pointed_thing)
+	if not ItemStack(minetest.get_node(pointed_thing.under).name):get_definition().pointable then
+		-- this should happen rarely
+		minetest.chat_send_player(placer:get_player_name(), "The block you have been building to has been dug/replaced!")
 		minetest.set_node(pos, oldnode)
 		return true
 	end
-	last_placement[name] = time
+	local name = placer:get_player_name()
+	local playerdata = players[name]
+	local time = minetest.get_us_time()
+	if (time - playerdata.last_placement) / 1e6 < 1 / blocks_per_second then
+		if (time - playerdata.last_chat_message_sent) / 1e6 >= resend_chat_message_seconds then
+			chat_send_player(placer:get_player_name(), "You are placing blocks too fast (more than " .. blocks_per_second .. " blocks per second) !")
+			playerdata.last_chat_message_sent = time
+		end
+		minetest.set_node(pos, oldnode)
+		return true
+	end
+	playerdata.last_placement = time
 end)

--- a/mods/pvp/place_limit/mod.conf
+++ b/mods/pvp/place_limit/mod.conf
@@ -1,0 +1,2 @@
+name = place_limit
+description = Limits block placement


### PR DESCRIPTION
Second try (see #698), as I'm still frustrated with how node placement is abused. Simple solution: Limits node placement to a sane speed. Can be increased to 10 nodes per second if too slow. ~~Won't apply to team doors unless [this fix](https://github.com/MT-CTF/capturetheflag/pull/698/files#diff-3de2a0a8a27905263bcf2f5a3213265e015b7408874b6ed27a307aade5d91ecfR357-R370) is implemented too~~. Fixes #819. Fixes #820.