### PR TITLE
Change grapple hook warning message

### DIFF
--- a/mods/ctf/ctf_classes/ranged.lua
+++ b/mods/ctf/ctf_classes/ranged.lua
@@ -49,7 +49,7 @@ local function check_grapple(itemname)
 		on_use = function(itemstack, user, ...)
 			if not ctf_classes.get(user).properties.allow_grapples then
 				minetest.chat_send_player(user:get_player_name(),
-					"Your class can't use that weapon! Change your class at spawn")
+					"Your class can't use that weapon! Change your class at base")
 
 				return itemstack
 			end


### PR DESCRIPTION
When you throw grapple hook it says "Your class can't use that weapon! Change your class at spawn". I changed it like in #802 PR