### PR TITLE
Sword marker: Decrease cooldown, fix trivial bug

### DIFF
--- a/mods/ctf/ctf_classes/melee.lua
+++ b/mods/ctf/ctf_classes/melee.lua
@@ -29,7 +29,7 @@ end, true)
 
 
 local sword_special_timer = {}
-local SWORD_SPECIAL_COOLDOWN = 10
+local SWORD_SPECIAL_COOLDOWN = 20
 local function sword_special_timer_func(pname, timeleft)
 	sword_special_timer[pname] = timeleft
 
@@ -57,7 +57,7 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		local pname = placer:get_player_name()
 		if not pointed_thing then return end
 
-		if (sword_special_timer[pname] and placer:get_player_control().sneak) then
+		if sword_special_timer[pname] and placer:get_player_control().sneak then
 			minetest.chat_send_player(pname, "You have to wait "..sword_special_timer[pname].."s to place marker again")
 
 			if pointed_thing.type == "node" then

--- a/mods/ctf/ctf_classes/melee.lua
+++ b/mods/ctf/ctf_classes/melee.lua
@@ -29,7 +29,7 @@ end, true)
 
 
 local sword_special_timer = {}
-local SWORD_SPECIAL_COOLDOWN = 40
+local SWORD_SPECIAL_COOLDOWN = 10
 local function sword_special_timer_func(pname, timeleft)
 	sword_special_timer[pname] = timeleft
 
@@ -57,7 +57,7 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		local pname = placer:get_player_name()
 		if not pointed_thing then return end
 
-		if sword_special_timer[pname] then
+		if (sword_special_timer[pname] and placer:get_player_control().sneak) then
 			minetest.chat_send_player(pname, "You can't place a marker yet (>"..sword_special_timer[pname].."s left)")
 
 			if pointed_thing.type == "node" then
@@ -102,8 +102,8 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		-- Check if player is sneaking before placing marker
 		if not placer:get_player_control().sneak then return end
 
-		sword_special_timer[pname] = 20
-		sword_special_timer_func(pname, 20)
+		sword_special_timer[pname] = 5
+		sword_special_timer_func(pname, 5)
 
 		minetest.registered_chatcommands["m"].func(pname, "Marked with "..pname.."'s sword")
 	end,

--- a/mods/ctf/ctf_classes/melee.lua
+++ b/mods/ctf/ctf_classes/melee.lua
@@ -58,7 +58,7 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		if not pointed_thing then return end
 
 		if (sword_special_timer[pname] and placer:get_player_control().sneak) then
-			minetest.chat_send_player(pname, "You can't place a marker yet ("..sword_special_timer[pname].."s left)")
+			minetest.chat_send_player(pname, "You have to wait "..sword_special_timer[pname].."s to place marker again")
 
 			if pointed_thing.type == "node" then
 				return minetest.item_place(itemstack, placer, pointed_thing)
@@ -102,8 +102,8 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		-- Check if player is sneaking before placing marker
 		if not placer:get_player_control().sneak then return end
 
-		sword_special_timer[pname] = 3
-		sword_special_timer_func(pname, 3)
+		sword_special_timer[pname] = 4
+		sword_special_timer_func(pname, 4)
 
 		minetest.registered_chatcommands["m"].func(pname, "Marked with "..pname.."'s sword")
 	end,

--- a/mods/ctf/ctf_classes/melee.lua
+++ b/mods/ctf/ctf_classes/melee.lua
@@ -33,8 +33,8 @@ local SWORD_SPECIAL_COOLDOWN = 10
 local function sword_special_timer_func(pname, timeleft)
 	sword_special_timer[pname] = timeleft
 
-	if timeleft - 10 >= 0 then
-		minetest.after(10, sword_special_timer_func, pname, timeleft - 10)
+	if timeleft - 1 >= 0 then
+		minetest.after(1, sword_special_timer_func, pname, timeleft - 1)
 	else
 		sword_special_timer[pname] = nil
 	end
@@ -58,7 +58,7 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		if not pointed_thing then return end
 
 		if (sword_special_timer[pname] and placer:get_player_control().sneak) then
-			minetest.chat_send_player(pname, "You can't place a marker yet (>"..sword_special_timer[pname].."s left)")
+			minetest.chat_send_player(pname, "You can't place a marker yet ("..sword_special_timer[pname].."s left)")
 
 			if pointed_thing.type == "node" then
 				return minetest.item_place(itemstack, placer, pointed_thing)
@@ -102,8 +102,8 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		-- Check if player is sneaking before placing marker
 		if not placer:get_player_control().sneak then return end
 
-		sword_special_timer[pname] = 5
-		sword_special_timer_func(pname, 5)
+		sword_special_timer[pname] = 3
+		sword_special_timer_func(pname, 3)
 
 		minetest.registered_chatcommands["m"].func(pname, "Marked with "..pname.."'s sword")
 	end,

--- a/mods/ctf/ctf_classes/melee.lua
+++ b/mods/ctf/ctf_classes/melee.lua
@@ -33,8 +33,8 @@ local SWORD_SPECIAL_COOLDOWN = 10
 local function sword_special_timer_func(pname, timeleft)
 	sword_special_timer[pname] = timeleft
 
-	if timeleft - 1 >= 0 then
-		minetest.after(1, sword_special_timer_func, pname, timeleft - 1)
+	if timeleft - 2 >= 0 then
+		minetest.after(2, sword_special_timer_func, pname, timeleft - 2)
 	else
 		sword_special_timer[pname] = nil
 	end


### PR DESCRIPTION
![slika](https://user-images.githubusercontent.com/47271658/110969183-aeec1400-8358-11eb-8179-b2e29ee9bbf6.png)

PR decreases cooldown to 3s instead of 20s and removes bug: currently when you open team chest or doors with sword in hand you get "can't place marker yet" message:
![Zaslonska slika 2021-03-12 16-52-44](https://user-images.githubusercontent.com/47271658/110969419-f4a8dc80-8358-11eb-8897-741dec0b0c68.png)


Tested and everything works, is ready to be merged.
![Zaslonska slika 2021-03-12 17-19-06](https://user-images.githubusercontent.com/47271658/110969489-08ecd980-8359-11eb-90c1-37d0d39962c5.png)


P.S. PR also makes that timer `timeleft` is checked every second. Currently it checked every 10 seconds. ~~I hope it won't make more lag.~~