### PR TITLE
Sprint gets reset to full on new game

### DIFF
--- a/mods/other/sprint/init.lua
+++ b/mods/other/sprint/init.lua
@@ -124,15 +124,15 @@ minetest.register_on_leaveplayer(function(player)
 end)
 
 ctf_match.register_on_new_match(function()
-	local players = minetest.get_connected_players()
-	for _, player in ipairs(players) do
+	local connected_players = minetest.get_connected_players()
+	for _, player in ipairs(connected_players) do
 		players[player:get_player_name()].stamina = STAMINA_MAX
 	end
 end)
 
 ctf.register_on_new_game(function()
-	local players = minetest.get_connected_players()
-	for _, player in ipairs(players) do
+	local connected_players = minetest.get_connected_players()
+	for _, player in ipairs(connected_players) do
 		players[player:get_player_name()].stamina = STAMINA_MAX
 	end
 end)

--- a/mods/other/sprint/init.lua
+++ b/mods/other/sprint/init.lua
@@ -122,3 +122,17 @@ end)
 minetest.register_on_leaveplayer(function(player)
 	players[player:get_player_name()] = nil
 end)
+
+ctf_match.register_on_new_match(function()
+	local players = minetest.get_connected_players()
+	for _, player in ipairs(players) do
+		players[player:get_player_name()].stamina = STAMINA_MAX
+	end
+end)
+
+ctf.register_on_new_game(function()
+	local players = minetest.get_connected_players()
+	for _, player in ipairs(players) do
+		players[player:get_player_name()].stamina = STAMINA_MAX
+	end
+end)

--- a/mods/other/sprint/init.lua
+++ b/mods/other/sprint/init.lua
@@ -126,7 +126,7 @@ end)
 ctf_match.register_on_new_match(function()
 	local connected_players = minetest.get_connected_players()
 	for _, player in ipairs(connected_players) do
-		players[player:get_player_name()].stamina = STAMINA_MAX
+		player[player:get_player_name()].stamina = STAMINA_MAX
 	end
 end)
 

--- a/mods/other/sprint/init.lua
+++ b/mods/other/sprint/init.lua
@@ -126,13 +126,13 @@ end)
 ctf_match.register_on_new_match(function()
 	local connected_players = minetest.get_connected_players()
 	for _, player in ipairs(connected_players) do
-		player[player:get_player_name()].stamina = STAMINA_MAX
+		players[player:get_player_name()].stamina = STAMINA_MAX
 	end
 end)
 
 ctf.register_on_new_game(function()
 	local connected_players = minetest.get_connected_players()
 	for _, player in ipairs(connected_players) do
-		player[player:get_player_name()].stamina = STAMINA_MAX
+		players[player:get_player_name()].stamina = STAMINA_MAX
 	end
 end)

--- a/mods/other/sprint/init.lua
+++ b/mods/other/sprint/init.lua
@@ -122,17 +122,10 @@ end)
 minetest.register_on_leaveplayer(function(player)
 	players[player:get_player_name()] = nil
 end)
-
-ctf_match.register_on_new_match(function()
-	local connected_players = minetest.get_connected_players()
-	for _, player in ipairs(connected_players) do
-		players[player:get_player_name()].stamina = STAMINA_MAX
-	end
-end)
-
-ctf.register_on_new_game(function()
-	local connected_players = minetest.get_connected_players()
-	for _, player in ipairs(connected_players) do
-		players[player:get_player_name()].stamina = STAMINA_MAX
-	end
+minetest.register_on_mods_loaded(function()
+	ctf_match.register_on_new_match(function()
+		for _, player in pairs(players) do
+			player.stamina = STAMINA_MAX
+		end
+	end)
 end)

--- a/mods/other/sprint/init.lua
+++ b/mods/other/sprint/init.lua
@@ -133,6 +133,6 @@ end)
 ctf.register_on_new_game(function()
 	local connected_players = minetest.get_connected_players()
 	for _, player in ipairs(connected_players) do
-		players[player:get_player_name()].stamina = STAMINA_MAX
+		player[player:get_player_name()].stamina = STAMINA_MAX
 	end
 end)


### PR DESCRIPTION
im not sure what the difference is between ```ctf_match.register_on_new_match(function())``` and ```ctf.register_on_new_game(function())``` so im not sure which i need to use(feel free to make suggestions if you know) but if this works, then great