### PR TITLE
Immortal map nodes: Switch to tool group blacklist

### DIFF
--- a/mods/ctf/ctf_map/ctf_map_core/nodes.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/nodes.lua
@@ -82,21 +82,36 @@ local mod_prefixes = {
 	wool = "wool_";
 }
 
--- See Lua API, section "Node-only groups"
-local preserved_groups = {
-	bouncy = true;
-	connect_to_raillike = true;
-	disable_jump = true;
-	fall_damage_add_percent = true;
-	slippery = true;
+local tool_groups = {
+	dig_immediate = true
 }
 
-local function make_immortal(def)
-	local groups = {immortal = 1}
-	for group in pairs(preserved_groups) do
-		groups[group] = def.groups[group]
+local function add_tool_groups(def)
+	local caps = def.tool_capabilities
+	if not caps then
+		return
 	end
-	def.groups = groups
+	local groups = caps.groupcaps
+	if not groups then
+		return
+	end
+	for group in pairs(groups) do
+		tool_groups[group] = true
+	end
+end
+
+for _, def in pairs(minetest.registered_tools) do
+	add_tool_groups(def)
+end
+
+-- Add hand groups
+add_tool_groups(minetest.registered_items[""])
+
+local function make_immortal(def)
+	for group in pairs(tool_groups) do
+		def.groups[group] = nil
+	end
+	def.groups.immortal = 1
 	def.floodable = false
 	def.description = def.description and ("Indestructible " .. def.description)
 end


### PR DESCRIPTION
Originally intended as a fix for the non-connecting fences reported, this switches to a tool group blacklist instead of whitelisting node-only groups (which missed groups such as the fence one).