### PR TITLE
Spectator Privacy

### DIFF
--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -218,8 +218,12 @@ function ctf.join(name, team, force, by)
 			" has joined team " .. minetest.colorize(tcolor, team)
 	end
 
-	minetest.chat_send_all("*** " .. join_msg)
-	minetest.log("action", name .. " joined team " .. team)
+	if minetest.check_player_privs(name, {spectate = true}) then
+		minetest.log("action", name .. " joined team " .. team .. " unannounced (spectator)")
+	else
+		minetest.chat_send_all("*** " .. join_msg)
+		minetest.log("action", name .. " joined team " .. team)
+	end
 
 	for i = 1, #ctf.registered_on_join_team do
 		ctf.registered_on_join_team[i](name, team, prevteam)

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -103,8 +103,10 @@ minetest.register_chatcommand("team", {
 			local team = ctf.team(param)
 			local tcolor = "#" .. ctf.flag_colors[team.data.color]:sub(3, 8)
 			for pname, tplayer in pairs(team.players) do
-				i = i + 1
-				str = str .. "  " .. i .. ") " .. minetest.colorize(tcolor, pname) .. "\n"
+				if not minetest.check_player_privs(pname, {spectate=true}) then
+					i = i + 1
+					str = str .. "  " .. i .. ") " .. minetest.colorize(tcolor, pname) .. "\n"
+				end
 			end
 			str = "Team " .. minetest.colorize(tcolor, param) .. " (" .. i .. ") :\n" .. str
 			minetest.chat_send_player(name, str)
@@ -113,8 +115,12 @@ minetest.register_chatcommand("team", {
 				test = param
 			end
 			if ctf.player(test).team then
-				return true, test ..
+				if minetest.check_player_privs(test, {spectate=true}) then
+					return true, "Player " .. test .. " not found!"
+				else
+					return true, test ..
 						" is in team " .. ctf.player(test).team
+				end
 			else
 				return true, test.." is not in a team"
 			end

--- a/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
@@ -33,9 +33,9 @@ ctf_map.mapdir = minetest.get_modpath(minetest.get_current_modname()) .. "/maps/
 -- Modify server status message to include map info
 local map_str
 local mtversion = minetest.get_version().string
+local mtplayers = ""
 
 local function get_nonspectators()
-	mtplayers = ""
 	local players_tbl = {}
 	local players = minetest.get_connected_players()
 	for _, p in pairs(players) do

--- a/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
+++ b/mods/ctf/ctf_map/ctf_map_core/schem_map.lua
@@ -32,9 +32,26 @@ ctf_map.mapdir = minetest.get_modpath(minetest.get_current_modname()) .. "/maps/
 
 -- Modify server status message to include map info
 local map_str
-local old_server_status = minetest.get_server_status
+local mtversion = minetest.get_version().string
+
+local function get_nonspectators()
+	mtplayers = ""
+	local players_tbl = {}
+	local players = minetest.get_connected_players()
+	for _, p in pairs(players) do
+		local name = p:get_player_name()
+		if not minetest.check_player_privs(name, {spectate=true}) then
+			table.insert(players_tbl, name)
+		end
+	end
+	mtplayers = tostring(table.concat(players_tbl, ", "))
+	return mtplayers
+end
+
 function minetest.get_server_status(name, joined)
-	local status = old_server_status(name, joined)
+	local status = "# Server: version=" .. mtversion .. ", uptime=" ..
+	math.floor(minetest.get_server_uptime()) .. ", clients={" .. get_nonspectators() ..
+	"}\n# Server: Welcome to CTF!"
 
 	if not ctf_map.map or not map_str then
 		return status


### PR DESCRIPTION
- Do not show spectators in join messages (leave messages are handled by the spectator mod itself)
- Do not show spectators in /team or /status
Other relevant PR: [here](https://github.com/MT-CTF/servermods/pull/23)