### PR TITLE
Rework melee damage

### DIFF
--- a/mods/ctf/ctf/teams.lua
+++ b/mods/ctf/ctf/teams.lua
@@ -450,6 +450,10 @@ function ctf.can_attack(player, hitter, time_from_last_punch, tool_capabilities,
 	return true
 end
 
+function ctf.get_damage_modifier(player, tool_capabilities)
+	return 0
+end
+
 ctf.registered_on_attack = {}
 function ctf.register_on_attack(func)
 	if ctf._mt_loaded then
@@ -458,25 +462,14 @@ function ctf.register_on_attack(func)
 	table.insert(ctf.registered_on_attack, func)
 end
 
-local dead_players = {}
-minetest.register_on_respawnplayer(function(player)
-	dead_players[player:get_player_name()] = nil
-end)
-minetest.register_on_joinplayer(function(player)
-	dead_players[player:get_player_name()] = nil
-end)
 minetest.register_on_punchplayer(function(player, hitter,
-		time_from_last_punch, tool_capabilities, dir, damage, ...)
+		time_from_last_punch, tool_capabilities, dir, orig_damage, ...)
 	if player and hitter then
 		local pname = player:get_player_name()
 		local hname = hitter:get_player_name()
 
 		local to = ctf.player(pname)
 		local from = ctf.player(hname)
-
-		if dead_players[pname] then
-			return
-		end
 
 		if to.team == from.team and to.team ~= "" and
 				to.team ~= nil and to.name ~= from.name then
@@ -491,25 +484,23 @@ minetest.register_on_punchplayer(function(player, hitter,
 		end
 
 		if ctf.can_attack(player, hitter, time_from_last_punch, tool_capabilities,
-			dir, damage, ...) == false
+			dir, orig_damage, ...) == false
 		then
 			return true
 		end
 
 		local hp = player:get_hp()
-		if hp == 0 then
-			return false
+		if hp <= 0 then
+			return true
 		end
 
-		if hp - damage <= 0 then
-			dead_players[pname] = true
-			local wielded = hitter:get_wielded_item()
-			for i = 1, #ctf.registered_on_killedplayer do
-				ctf.registered_on_killedplayer[i](pname, hname,
-						wielded, tool_capabilities)
-			end
-			return false
+		if tool_capabilities and tool_capabilities.damage_groups and tool_capabilities.damage_groups.fleshy then
+			local modifier = ctf.get_damage_modifier(hitter, tool_capabilities)
+			tool_capabilities.damage_groups.fleshy = math.max(1, tool_capabilities.damage_groups.fleshy + modifier)
 		end
+
+		local damage = minetest.get_hit_params(player:get_armor_groups(), tool_capabilities, time_from_last_punch).hp
+		damage = math.min(damage, hp)
 
 		for i = 1, #ctf.registered_on_attack do
 			ctf.registered_on_attack[i](
@@ -517,5 +508,14 @@ minetest.register_on_punchplayer(function(player, hitter,
 				tool_capabilities, dir, damage, ...
 			)
 		end
+
+		if hp <= damage then
+			for i = 1, #ctf.registered_on_killedplayer do
+				ctf.registered_on_killedplayer[i](pname, hname,	tool_capabilities)
+			end
+		end
+
+		player:set_hp(hp - damage)
+		return true
 	end
 end)

--- a/mods/ctf/ctf_classes/classes.lua
+++ b/mods/ctf/ctf_classes/classes.lua
@@ -8,7 +8,7 @@ ctf_classes.register("knight", {
 	properties = {
 		max_hp = 30,
 		speed = 0.90,
-		melee_bonus = 1,
+		sword_modifier = 1,
 
 		initial_stuff = {
 			"ctf_classes:sword_bronze",

--- a/mods/ctf/ctf_classes/init.lua
+++ b/mods/ctf/ctf_classes/init.lua
@@ -69,3 +69,16 @@ ctf_classes.register_on_changed(function(player, old, new)
 	ctf.chat_send_team(ctf.player(pname).team,
 			minetest.colorize("#ABCDEF", pname .. " is now a " .. new.description))
 end)
+
+local old_get_damage_modifier = ctf.get_damage_modifier
+function ctf.get_damage_modifier(player, tool_capabilities)
+	local modifier = 0
+	if tool_capabilities.damage_groups.sword then
+		local class = ctf_classes.get(player)
+		if class.properties.sword_modifier then
+			modifier = class.properties.sword_modifier
+		end
+	end
+
+	return modifier + old_get_damage_modifier(player, tool_capabilities)
+end

--- a/mods/ctf/ctf_classes/melee.lua
+++ b/mods/ctf/ctf_classes/melee.lua
@@ -1,33 +1,3 @@
-minetest.register_on_player_hpchange(function(player, hp_change, reason)
-	if reason.type ~= "punch" or not reason.object or not reason.object:is_player() then
-		return hp_change
-	end
-
-	local class = ctf_classes.get(reason.object)
-
-	if class.properties.melee_bonus and reason.object:get_wielded_item():get_name():find("sword") then
-		local change = hp_change - class.properties.melee_bonus
-
-		if player:get_hp() + change <= 0 and player:get_hp() + hp_change > 0 then
-			local wielded_item = reason.object:get_wielded_item()
-
-			for i = 1, #ctf.registered_on_killedplayer do
-				ctf.registered_on_killedplayer[i](
-					player:get_player_name(),
-					reason.object:get_player_name(),
-					wielded_item,
-					wielded_item:get_tool_capabilities()
-				)
-			end
-		end
-
-		return change
-	end
-
-	return hp_change
-end, true)
-
-
 local sword_special_timer = {}
 local SWORD_SPECIAL_COOLDOWN = 20
 local function sword_special_timer_func(pname, timeleft)
@@ -68,7 +38,6 @@ minetest.register_tool("ctf_classes:sword_bronze", {
 		end
 
 		local pteam = ctf.player(pname).team
-
 		if not pteam then -- can be nil during map change
 			return
 		end

--- a/mods/ctf/ctf_events/init.lua
+++ b/mods/ctf/ctf_events/init.lua
@@ -120,7 +120,7 @@ function ctf_events.update_all()
 	end
 end
 
-ctf.register_on_killedplayer(function(victim, killer, stack, tool_caps)
+ctf.register_on_killedplayer(function(victim, killer, tool_caps)
 	local victim_color = ctf_colors.get_color(ctf.player(victim))
 	local killer_color = ctf_colors.get_color(ctf.player(killer))
 

--- a/mods/ctf/ctf_metrics/init.lua
+++ b/mods/ctf/ctf_metrics/init.lua
@@ -15,7 +15,7 @@ end
 -- Kills
 --
 local kill_counter = counter("ctf_kills", "Total kills")
-ctf.register_on_killedplayer(function(victim, killer, type)
+ctf.register_on_killedplayer(function(victim, killer)
 	kill_counter:increment()
 end)
 

--- a/mods/pvp/anticoward/init.lua
+++ b/mods/pvp/anticoward/init.lua
@@ -38,12 +38,11 @@ ctf.register_on_attack(function(player, hitter,
 
 		potential_cowards[pname].timer = 0
 		potential_cowards[pname].puncher = hname
-		potential_cowards[pname].wielded_item = hitter:get_wielded_item()
 		potential_cowards[pname].toolcaps = tool_capabilities
 	end
 end)
 
-ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
+ctf.register_on_killedplayer(function(victim, killer, toolcaps)
 	if toolcaps.damage_groups.combat_log or toolcaps.damage_groups.suicide then
 		return
 	end
@@ -72,7 +71,6 @@ function handle_leave_or_die(pname, leave)
 			ctf.registered_on_killedplayer[i](
 				pname,
 				hname,
-				potential_cowards[pname].wielded_item,
 				potential_cowards[pname].toolcaps
 			)
 		end

--- a/mods/pvp/kill_assist/init.lua
+++ b/mods/pvp/kill_assist/init.lua
@@ -69,7 +69,7 @@ function kill_assist.reward_assists(victim, killer, reward)
 	kill_assist.clear_assists(victim)
 end
 
-ctf.register_on_killedplayer(function(victim, killer, _, toolcaps)
+ctf.register_on_killedplayer(function(victim, killer, toolcaps)
 	local reward = ctf_stats.calculateKillReward(victim, killer, toolcaps)
 	reward = math.floor(reward * 100) / 100
 	kill_assist.reward_assists(victim, killer, reward)

--- a/mods/pvp/medkits/init.lua
+++ b/mods/pvp/medkits/init.lua
@@ -133,22 +133,21 @@ end)
 
 -- If player takes damage while healing,
 -- stop regen and revert back to original state
-minetest.register_on_player_hpchange(function(player, hp, reason)
+minetest.register_on_player_hpchange(function(player, hp_change, reason)
 	local name = player:get_player_name()
-	if hp < 0 then
+	if hp_change < 0 then
 		if players[name] then
 			player:hud_remove(players[name].hud)
 			players[name] = nil -- Don't use stop_healing(), it uses set_hp() and won't allocate deaths or score properly
 		end
-		if reason and reason.type == "punch" then
+		if reason.type == "punch" then
 			local hitter = reason.object
 			if hitter and players[hitter:get_player_name()] then
 				stop_healing(hitter, "attack")
 			end
 		end
 	end
-	return hp
-end, true)
+end)
 
 minetest.register_on_leaveplayer(function(player)
 	players[player:get_player_name()] = nil


### PR DESCRIPTION
Introduce get_damage_modifier, change player hp in register_on_punchplayer.
Avoid using register_on_player_hpchange callback as it doesn't account kill assists correctly.