### PR TITLE
Fix build timer off-by-one error

### DIFF
--- a/mods/ctf/ctf_modebase/build_timer.lua
+++ b/mods/ctf/ctf_modebase/build_timer.lua
@@ -7,7 +7,7 @@ local timer = nil
 ctf_modebase.build_timer = {}
 
 local function timer_func(time_left)
-	if time_left <= 1 then
+	if time_left <= 0 then
 		ctf_modebase.build_timer.finish()
 		return
 	end


### PR DESCRIPTION
Without this fix, it always ends at `0m 2s until match begins`, which is mildly annoying.