### PR TITLE
Mode vote: Add validation, default to no vote

### DIFF
--- a/mods/ctf/ctf_modebase/mode_vote.lua
+++ b/mods/ctf/ctf_modebase/mode_vote.lua
@@ -42,7 +42,10 @@ local function show_modechoose_form(player)
 				pos = {"center", 4},
 				func = function(playername, fields)
 					if votes then
-						player_vote(player, tonumber(fields.amount) or 5)
+						local amount = tonumber(fields.amount)
+						if amount and amount % 1 == 0 and amount >= 0 and amount <= 5 then
+							player_vote(player, amount)
+						end
 					end
 				end,
 			}


### PR DESCRIPTION
Closes #989. Also replaces the `or 5` by a no-op, meaning invalid votes just won't be counted instead of being counted as `5`.