### PR TITLE
Establish vote count ordering

### DIFF
--- a/mods/ctf/ctf_modebase/mode_vote.lua
+++ b/mods/ctf/ctf_modebase/mode_vote.lua
@@ -106,7 +106,7 @@ function ctf_modebase.mode_vote.end_vote()
 	local average_vote = 0
 	local entry_count = 0
 	for length = 1, MAX_ROUNDS do
-		vote_count = length_votes[length]
+		local vote_count = length_votes[length]
 		if vote_count then
 			votes_result = votes_result .. string.format(
 				"    %d vote%s for %d match%s\n",

--- a/mods/ctf/ctf_modebase/mode_vote.lua
+++ b/mods/ctf/ctf_modebase/mode_vote.lua
@@ -105,17 +105,19 @@ function ctf_modebase.mode_vote.end_vote()
 	local votes_result = ""
 	local average_vote = 0
 	local entry_count = 0
-	for length, vote_count in pairs(length_votes) do
-		votes_result = votes_result .. string.format(
-			"    %d vote%s for %d match%s\n",
-			vote_count,
-			vote_count == 1 and "" or "s",
-			length,
-			length == 1 and "" or "es"
-		)
-
-		entry_count = entry_count + vote_count
-		average_vote = average_vote + (length * vote_count)
+	for length = 1, MAX_ROUNDS do
+		vote_count = length_votes[length]
+		if vote_count then
+			votes_result = votes_result .. string.format(
+				"    %d vote%s for %d match%s\n",
+				vote_count,
+				vote_count == 1 and "" or "s",
+				length,
+				length == 1 and "" or "es"
+			)
+			entry_count = entry_count + vote_count
+			average_vote = average_vote + (length * vote_count)
+		end
 	end
 
 	if entry_count > 0 then


### PR DESCRIPTION
Currently vote counts aren't ordered. `pairs` traversal means any order is possible.

This is "fixed" here. Vote counts are output in ascending order. It does so by iterating over the lengths in the correct order and checking whether there are votes. Not an issue for a max of 5 rounds. Sorting would likely be less efficient and more of a hassle here.

Needs testing.