### PR TITLE
Allow maps to specify a spawn direction for each team

### DIFF
--- a/mods/ctf/ctf_map/map_meta.lua
+++ b/mods/ctf/ctf_map/map_meta.lua
@@ -6,6 +6,23 @@ function ctf_map.skybox_exists(subdir)
 	return table.indexof(list, "skybox") ~= -1
 end
 
+-- calc_flag_center() calculates the center of a map from the positions of the flags.
+local function calc_flag_center(map)
+	local flag_center = vector.zero()
+	local flag_count = 0
+
+	for _, team in pairs(map.teams) do
+		flag_center = flag_center + team.flag_pos
+		flag_count = flag_count + 1
+	end
+
+	flag_center = flag_center:apply(function(value)
+		return value / flag_count
+	end)
+
+	return flag_center
+end
+
 function ctf_map.load_map_meta(idx, dirname)
 	local meta = Settings(ctf_map.maps_dir .. dirname .. "/map.conf")
 
@@ -158,6 +175,8 @@ function ctf_map.load_map_meta(idx, dirname)
 			map.barrier_area = {pos1 = map.pos1, pos2 = map.pos2}
 		end
 	end
+
+	map.flag_center = calc_flag_center(map)
 
 	if ctf_map.skybox_exists(ctf_map.maps_dir .. dirname) then
 		skybox.add({dirname, "#ffffff", [5] = "png"})

--- a/mods/ctf/ctf_map/mapedit_gui.lua
+++ b/mods/ctf/ctf_map/mapedit_gui.lua
@@ -414,7 +414,55 @@ function ctf_map.show_map_save_form(player, scroll_pos)
 				end)
 			end,
 		}
-		idx = idx + 1.5
+		idx = idx + (0.7 / 2) + 0.3 + (0.3 / 2)
+
+		local look_pos = context[player].teams[teamname].look_pos
+
+		elements[teamname .. "_look_pos"] = {
+			type = "label",
+			label = "Look position: " .. (look_pos and vector.to_string(look_pos) or "auto"),
+			pos = {0.2, idx},
+			-- "The first line of text is now positioned centered exactly at the position specified."
+			-- https://github.com/minetest/minetest/blob/480d5f2d51ca8f7c4400b0918bb53b776e4ff440/doc/lua_api.txt#L2929
+		}
+		idx = idx + (0.3 / 2) + 0.1 + (0.7 / 2)
+
+		local btn_width = (9 - (ctf_gui.SCROLLBAR_WIDTH + 0.1) - 0.1) / 2
+
+		elements[teamname.."_look_pos_auto"] = {
+			type = "button",
+			label = "Auto",
+			pos = {0.2, idx - (ctf_gui.ELEM_SIZE.y / 2)},
+			size = {btn_width, ctf_gui.ELEM_SIZE.y},
+
+			func = function(pname, fields)
+				context[pname].teams[teamname].look_pos = nil
+
+				minetest.after(0.1, function()
+					ctf_map.show_map_save_form(pname, minetest.explode_scrollbar_event(fields.formcontent).value)
+				end)
+			end,
+		}
+
+		elements[teamname.."_look_pos_choose"] = {
+			type = "button",
+			label = "Choose",
+			pos = {0.2 + btn_width + 0.1, idx - (ctf_gui.ELEM_SIZE.y / 2)},
+			size = {btn_width, ctf_gui.ELEM_SIZE.y},
+
+			func = function(pname, fields)
+				ctf_map.get_pos_from_player(pname, 1, function(_, positions)
+					context[pname].teams[teamname].look_pos = positions[1]
+
+					minetest.after(0.1, function()
+						ctf_map.show_map_save_form(pname, minetest.explode_scrollbar_event(fields.formcontent).value)
+					end)
+				end)
+			end,
+			exit = true,
+		}
+
+		idx = idx + (0.7 / 2) + 0.3 + (0.7 / 2) + 0.5
 	end
 
 	-- CHEST ZONES

--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -66,7 +66,6 @@ end
 
 local function tp_player_near_flag(player)
 	local tname = ctf_teams.get(player)
-
 	if not tname then return end
 
 	local pos = vector.offset(ctf_map.current_map.teams[tname].flag_pos,
@@ -74,10 +73,20 @@ local function tp_player_near_flag(player)
 		0.5,
 		math.random(-1, 1)
 	)
-	player:set_pos(pos)
+	local rotation_y = vector.dir_to_rotation(
+		vector.direction(pos, ctf_map.current_map.teams[tname].look_pos or ctf_map.current_map.flag_center)
+	).y
+
+	local function apply()
+		player:set_pos(pos)
+		player:set_look_vertical(0)
+		player:set_look_horizontal(rotation_y)
+	end
+
+	apply()
 	minetest.after(0.1, function() -- TODO remove after respawn bug will be fixed
 		if player:is_player() then
-			player:set_pos(pos)
+			apply()
 		end
 	end)
 


### PR DESCRIPTION
![screenshot of the GUI](https://user-images.githubusercontent.com/82708541/165790562-1aedb21d-8649-41a7-b67e-3369132365fc.png)

### Context

This is an alternative to #1002. #1002 produces bad results on some maps:

![screenshot of a bad spawn direction 1](https://user-images.githubusercontent.com/82708541/165596041-56154658-2093-46a5-abb9-2feddd70375b.png)
![screenshot of a bad spawn direction 2](https://user-images.githubusercontent.com/82708541/165596045-bca4f56a-0769-473f-b92b-8e966c9065da.png)

Since there's probably no algorithm that works for all maps, I think it's better to specify the spawn directions manually.

