### PR TITLE
Make voting dialogue look better on small screens

### DIFF
--- a/mods/apis/ctf_gui/api.md
+++ b/mods/apis/ctf_gui/api.md
@@ -13,6 +13,7 @@ ctf_gui.old_show_formspec(player, "modname:formname", {
 	size = {x = <x size>, y = <y size>},
 	title = "Formspec Title",
 	description = "Text below the title",
+	header_height = 1.6,
 	privs = {server = true},
 	on_quit = function(playername, fields)
 		-- Called when player ESCs out of formspec

--- a/mods/apis/ctf_gui/init.lua
+++ b/mods/apis/ctf_gui/init.lua
@@ -168,15 +168,18 @@ function ctf_gui.old_show_formspec(player, formname, formdef)
 	if not formdef.size then
 		formdef.size = ctf_gui.FORM_SIZE
 	end
+	if not formdef.header_height then
+		formdef.header_height = 1.6
+	end
 
 	local maxyscroll = 0
 	local formspec = "formspec_version[4]" ..
 			string.format("size[%f,%f]", formdef.size.x, formdef.size.y) ..
-				"hypertext[0,0.2;"..formdef.size.x..
-					",1.6;title;<center><big>"..formdef.title.."</big>\n" ..
+				"hypertext[0,0.2;"..formdef.size.x..","..formdef.header_height..
+					";title;<center><big>"..formdef.title.."</big>\n" ..
 					(formdef.description or "\b") .."</center>]" ..
-				"scroll_container[0.1,1.5;"..formdef.size.x..
-				","..formdef.size.y..";formcontent;vertical]"
+				"scroll_container[0.1,"..(formdef.header_height-0.1)..";"
+					..formdef.size.x..","..formdef.size.y..";formcontent;vertical]"
 
 	local using_scrollbar = false
 	if formdef.elements then

--- a/mods/ctf/ctf_modebase/mode_vote.lua
+++ b/mods/ctf/ctf_modebase/mode_vote.lua
@@ -42,9 +42,10 @@ local function show_modechoose_form(player)
 	end
 
 	ctf_gui.old_show_formspec(player, "ctf_modebase:mode_select", {
-		size = {x = 8, y = MAX_ROUNDS + 3},
+		size = {x = 8, y = MAX_ROUNDS + 3.5},
 		title = "Mode: "..HumanReadable(new_mode),
 		description = "Please vote on how many matches you would like to play",
+		header_height = 2.4,
 		elements = elements,
 	})
 end


### PR DESCRIPTION
On smaller screens such as laptop screens, the voting dialogue's header shows a scroll bar. This pull request increases the header's size to remove the scroll bar.