### PR TITLE
ctf_chat: Prevent /msg from bypassing filter

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -12,7 +12,7 @@ globals = {
 	"dropondie", "grenades",
 
 	"chatcmdbuilder", "crafting", "hpbar", "playertag", "random_messages",
-	"skybox", "throwable_snow", "worldedit",
+	"skybox", "throwable_snow", "worldedit", "filter",
 
 	"default", "doors", "player_api", "sfinv", "binoculars",
 

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -10,6 +10,12 @@ minetest.override_chatcommand("msg", {
 			return false, "The player " .. sendto .. " is not online."
 		end
 
+		-- Run the message through filter if it exists
+		if filter and not filter.check_message(name, message) then
+			filter.on_violation(name, message)
+			return false
+		end
+
 		-- Message color
 		local color = minetest.settings:get("ctf_chat.message_color") or "#E043FF"
 		local pteam = ctf_teams.get(name)

--- a/mods/ctf/ctf_chat/mod.conf
+++ b/mods/ctf/ctf_chat/mod.conf
@@ -1,2 +1,3 @@
 name = ctf_chat
 depends = ctf_teams
+optional_depends = filter


### PR DESCRIPTION
Solution seems hacky to me. Surely `filter` must do this automatically? Maybe the `override_chatcommand` messes it up? I have no clue how this worked in v2 or earlier.

Tested; works.