### PR TITLE
[NO SQUASH] Prevent initial stuff being dropped upon player death

### DIFF
--- a/mods/ctf/ctf_modebase/player.lua
+++ b/mods/ctf/ctf_modebase/player.lua
@@ -15,6 +15,14 @@ local function get_initial_stuff(player, f)
 	end
 end
 
+function ctf_modebase.player.get_initial_stuff(player)
+	local initial_stuff = {}
+	get_initial_stuff(player, function(item)
+		table.insert(initial_stuff, item)
+	end)
+	return initial_stuff
+end
+
 function ctf_modebase.player.give_initial_stuff(player)
 	minetest.log("action", "Giving initial stuff to player " .. player:get_player_name())
 

--- a/mods/pvp/dropondie/init.lua
+++ b/mods/pvp/dropondie/init.lua
@@ -1,15 +1,47 @@
 dropondie = {}
 
-local function drop_list(pos, inv, list)
-	for _, item in ipairs(inv:get_list(list)) do
-		local obj = minetest.add_item(pos, item)
+local function drop_list(pos, player, listname)
+	local initial_stuff = ctf_modebase.player.get_initial_stuff(player)
+	local inv = player:get_inventory()
+	local invlist = inv:get_list(listname)
+	local newlist = {}
 
+	-- Move initial stuff from old list to new list
+	for list_i, item in ipairs(invlist) do
+		for stuff_i = 1, #initial_stuff do
+			-- Initialize this within loop so that the value can be changed within the loop
+			local i_item = initial_stuff[stuff_i]
+			if item:get_name() == i_item:get_name() then
+				-- Try to take out i_count
+				local count, i_count = item:get_count(), i_item:get_count()
+				local taken_item = item:take_item(i_count)
+				local taken_count = taken_item:get_count()
+
+				-- Add taken item to new list
+				newlist[list_i] = taken_item
+				if taken_count < i_count then
+					-- If full count wasn't recovered, update initial item's count
+					initial_stuff[stuff_i]:set_count(i_count - taken_count)
+				else
+					-- Else remove item so as to not count it again
+					initial_stuff[stuff_i]:clear()
+					initial_stuff[stuff_i] = nil
+				end
+				invlist[list_i] = item
+			end
+		end
+	end
+
+	-- Drop all remaining items in old list
+	for _, item in ipairs(invlist) do
+		local obj = minetest.add_item(pos, item)
 		if obj then
 			obj:set_velocity({ x = math.random(-1, 1), y = 5, z = math.random(-1, 1) })
 		end
 	end
 
-	inv:set_list(list, {})
+	-- Set new list containing only initial stuff
+	inv:set_list(listname, newlist)
 end
 
 function dropondie.drop_all(player)
@@ -19,7 +51,7 @@ function dropondie.drop_all(player)
 	local pos = player:get_pos()
 	pos.y = math.floor(pos.y + 0.5)
 
-	drop_list(pos, player:get_inventory(), "main")
+	drop_list(pos, player, "main")
 end
 
 if ctf_core.settings.server_mode ~= "mapedit" then


### PR DESCRIPTION
Closes #1041.

I've also added a method `ctf_modebase.player.get_initial_stuff(player)`. I can think of more use-cases where this information is necessary, apart from this PR.

### How it werks

In `dropondie`, the invlist to be dropped as items is first removed of all `initial_stuff` for that player. The `initial_stuff` is moved to a new invlist of equal size, and the indices of these initial items are preserved from the original invlist. What remains in the original invlist is then dropped.

The second part of the PR (which is currently WIP) is to not keep giving the initial stuff on every respawn, as they're preserved across deaths now.

### Proposed changes
- [x] Add method `ctf_modebase.player.get_initial_stuff(player)` - includes initial items from both map and class.
  - returns `{ itemstack, itemstack2, itemstack3 }`
- [x] Don't drop initial stuff upon death
- [ ] Prevent initial stuff from being given every respawn
- [ ] Testing. More testing. MOAR testing

### Testing procedure

1. Launch CTF. `singleplayer` *should* be fine.
2. Run the following commands:
  2.1. `/grantme ctf_admin`
  2.2. `/ctf_next -f mode:classes caverns`
3. Arrange your inventory in your own preferred way **OR** in any random bizzare way.
4. Die. Just die; how you die doesn't matter - no one cares about you. :P
5. Once you respawn, make sure you have the default items in the same slots as you had left them. Make sure you have exactly 20 torches and 5 sticks.
6. Try these different scenarios after each respawn:
  6.1. Throw out 10 torches, so that you're left with only 10 torches.
  6.2. Collect more torches so that you have more than 20 cobble.
  6.3. Don't add or remove any torches in your inventory, but split the existing torches into multiple stacks.
7. Go to step 3. Keep dying until you're either satisfied with the PR or fed up with life.

Werk-in-progress. Don't start testing right now - I'll let you know when the PR is ready.