### PR TITLE
ctf_chat: Replace the sender-side response for /msg

### DIFF
--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -31,7 +31,7 @@ minetest.override_chatcommand("msg", {
 		str = "Message sent to " .. sendto .. ": " .. message
 
 		minetest.log("action", string.format("[CHAT] PM from %s to %s: %s", name, sendto, message))
-		
+
 		-- Send the sender-side message
 		return true, str
 	end

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -27,10 +27,8 @@ minetest.override_chatcommand("msg", {
 		str = str .. minetest.colorize(color, ": " .. message)
 		minetest.chat_send_player(sendto, str)
 
-		-- Colorize the sender-side message
-		str = minetest.colorize (color, "To ")
-		str = str .. minetest.colorize(tcolor, name)
-		str = str .. minetest.colorize(color, ": " .. message)
+		-- Make the sender-side message
+		str = "To " .. name .. ": " .. message
 
 		minetest.log("action", string.format("[CHAT] PM from %s to %s: %s", name, sendto, message))
 		

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -21,14 +21,21 @@ minetest.override_chatcommand("msg", {
 		local pteam = ctf_teams.get(name)
 		local tcolor = pteam and ctf_teams.team[pteam].color or "#FFF"
 
-		-- Colorized sender name and message
+		-- Colorize the recepient-side message and send it to the recepient
 		local str =  minetest.colorize(color, "PM from ")
 		str = str .. minetest.colorize(tcolor, name)
 		str = str .. minetest.colorize(color, ": " .. message)
 		minetest.chat_send_player(sendto, str)
 
+		-- Colorize the sender-side message
+		str = minetest.colorize (color, "To ")
+		str = str .. minetest.colorize(tcolor, name)
+		str = str .. minetest.colorize(color, ": " .. message)
+
 		minetest.log("action", string.format("[CHAT] PM from %s to %s: %s", name, sendto, message))
-		return true, "Message sent."
+		
+		-- Send the sender-side message
+		return true, str
 	end
 })
 

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -28,7 +28,7 @@ minetest.override_chatcommand("msg", {
 		minetest.chat_send_player(sendto, str)
 
 		-- Make the sender-side message
-		str = "To " .. name .. ": " .. message
+		str = "To " .. sendto .. ": " .. message
 
 		minetest.log("action", string.format("[CHAT] PM from %s to %s: %s", name, sendto, message))
 		

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -28,7 +28,7 @@ minetest.override_chatcommand("msg", {
 		minetest.chat_send_player(sendto, str)
 
 		-- Make the sender-side message
-		str = "To " .. sendto .. ": " .. message
+		str = "Message sent to " .. sendto .. ": " .. message
 
 		minetest.log("action", string.format("[CHAT] PM from %s to %s: %s", name, sendto, message))
 		


### PR DESCRIPTION
Currently when you send a private message, you get a nondescript `Message sent.`, which makes it harder to talk. The changes will make /msg give out `To <RECEPIENT>: <MESSAGE>` instead.