### PR TITLE
ctf_combat: Make sure that players can't use medkits while inside blocks

### DIFF
--- a/mods/ctf/ctf_combat/ctf_healing/medkit.lua
+++ b/mods/ctf/ctf_combat/ctf_healing/medkit.lua
@@ -49,6 +49,15 @@ local function medkit_heal(playername)
 			return stop_medkit_heal(playername, "You stopped holding the medkit")
 		end
 
+		-- In case teammates manage to place blocks inside the player while they're healing
+		local pos = player:get_pos()
+		local node_0 = minetest.get_node(pos)
+		local node_0 = minetest.get_node(pos:offset(0, 1, 0))
+
+		if minetest.registered_nodes[node_0].walkable or minetest.registered_nodes[node_1].walkable then
+			return stop_medkit_heal(playername, "You can't heal while inside blocks")
+		end
+
 		local max_hp = player:get_properties().hp_max
 		local new_hp = math.min(player:get_hp() + REGEN_PER_SEC, max_hp)
 
@@ -133,6 +142,20 @@ minetest.register_tool("ctf_healing:medkit", {
 	inventory_image = "ctf_healing_medkit.png",
 	on_use = function(itemstack, user, pointed_thing)
 		local uname = user:get_player_name()
+		
+		-- Prevent players from using medkits while inside nodes
+		local pos = user:get_pos()
+		local node_0 = minetest.get_node(pos).name
+		local node_1 = minetest.get_node(pos:offset(0, 1, 0)).name
+
+		if minetest.registered_nodes[node_0].walkable or minetest.registered_nodes[node_1].walkable then
+			hud_events.new(uname, {
+				text = "You can't heal inside blocks",
+				color = "danger",
+				quick = true,
+			})
+			return
+		end
 
 		if not healing_players[uname] then
 			start_medkit_heal(uname)


### PR DESCRIPTION
This should close #1027. I have also made sure that the healing stops if teammates manage to place blocks inside the healed player.