### PR TITLE
Fix Minetest path text

### DIFF
--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -105,7 +105,7 @@ Areas where chests can be placed. Some maps allow placing chests anywhere, while
 
 1. Press "Finish Editing"
 2. Find the exported map
-3. Move to \[Minetest folder]/games/capturetheflag/mods/ctf/ctf_map/maps
+3. Move to the Minetest folder, which should be similar to `.../games/capturetheflag/mods/ctf/ctf_map/maps`
 
 ### 7. Play
 


### PR DESCRIPTION
Things added/changed:

- Fix the Minetest path text in the CTF map guide.
  - The text to the `ctf_map` directory seemed to be wrong. I hope it looks better this way. 🙂
