### PR TITLE
Fix for /lb showing bounty score

### DIFF
--- a/mods/ctf/ctf_modebase/bounties.lua
+++ b/mods/ctf/ctf_modebase/bounties.lua
@@ -152,7 +152,7 @@ ctf_core.register_chatcommand_alias("list_bounties", "lb", {
 					"label[%d,0.1;%s: %s score]",
 					x,
 					bounty.name,
-					minetest.colorize("cyan", bounty.rewards.score)
+					minetest.colorize("cyan", math.floor(bounty.rewards.score))
 				)
 
 				table.insert(output, label)


### PR DESCRIPTION
`/lb` sometimes shows values like `18.6666...`. This fixes that using `math.floor`