### PR TITLE
Fix the bug of damage cobble when match hasn't yet started

### DIFF
--- a/mods/ctf/ctf_map/ctf_traps.lua
+++ b/mods/ctf/ctf_map/ctf_traps.lua
@@ -113,13 +113,16 @@ local function damage_cobble_dig(pos, node, digger)
 	if not digger:is_player() then return end
 
 	local digger_name = digger:get_player_name()
-	local digger_team = ctf_teams.get(digger_name)
+	local digger_team = ctf_teams.get(digger_name) 
 
 	local meta = minetest.get_meta(pos)
 	local placer_name = meta:get_string("placer")
 	meta:set_string("placer", "")
 
 	local placer_team = ctf_teams.get(placer_name)
+	if placer_team ~= digger_team and not ctf_modebase.match_started then
+		return
+	end
 
 	if digger_team == placer_team then return end
 

--- a/mods/ctf/ctf_map/ctf_traps.lua
+++ b/mods/ctf/ctf_map/ctf_traps.lua
@@ -113,7 +113,7 @@ local function damage_cobble_dig(pos, node, digger)
 	if not digger:is_player() then return end
 
 	local digger_name = digger:get_player_name()
-	local digger_team = ctf_teams.get(digger_name) 
+	local digger_team = ctf_teams.get(digger_name)
 
 	local meta = minetest.get_meta(pos)
 	local placer_name = meta:get_string("placer")


### PR DESCRIPTION
With this PR, #1095 will be closed and damage cobbles cannot be removed before match start from an enemy.