### PR TITLE
changing definition of pro

### DIFF
--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -491,7 +491,7 @@ return {
 			if
 				((rank.kills or 0) + (rank.kill_assists or 0) * 0.34) / (rank.deaths or 1) >= 1.4 or
 				(rank.flag_captures or 0) / (rank.deaths or 1) >= 1/14 or
-				(rank.hp_healed or 0) / (rank.deaths or 1) >= 30 
+				(rank.hp_healed or 0) / (rank.deaths or 1) >= 30
 			then
 				return true, true
 			end

--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -481,16 +481,19 @@ return {
 
 		-- Remember to update /make_pro in ranking_commands.lua if you change anything here
 		if rank then
+			if (rank.score or 0) <= 8000 then
+				if (rank.score or 0) >= 10 then
+					return true, deny_pro
+				else
+					return false, deny_pro
+				end
+			end
 			if
-				(rank.score or 0) >= 8000 and
-				(rank.kills or 0) / (rank.deaths or 1) >= 1.4 and
-				(rank.flag_captures or 0) >= 5
+				((rank.kills or 0) + (rank.kill_assists or 0) * 0.34) / (rank.deaths or 1) >= 1.4 or
+				(rank.flag_captures or 0) / (rank.deaths or 1) >= 1/14 or
+				(rank.hp_healed or 0) / (rank.deaths or 1) >= 30 
 			then
 				return true, true
-			end
-
-			if (rank.score or 0) >= 10 then
-				return true, deny_pro
 			end
 		end
 

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -233,7 +233,7 @@ minetest.register_chatcommand("make_pro", {
 			return false, string.format("Player '%s' has no rankings!", pname)
 		end
 
-		mode_data.rankings:add(pname, {score = 8000, kills = 7, deaths = 5, flag_captures = 5})
+		mode_data.rankings:add(pname, {score = 8000, kills = 7, deaths = 5, flag_captures = 1, hp_healed = 100})
 
 		minetest.log("action", string.format(
 			"[ctf_admin] %s made player '%s' a pro in mode %s: %s", name, pname, mode_name, dump(old_ranks)


### PR DESCRIPTION
This PR changes definition of a pro player to one who has at least 8000 score and at least one of these requirements:

 - K/D is at least 1.4(each kill assist counts as 1/3 kill)
 - H/D is at least 30(30 hp healed for every one death)
 - C/D is at least 1/14(one capture for every 14 deaths)