### PR TITLE
Update ctf_map READ.ME screenshot instructions

### DIFF
--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -120,11 +120,10 @@ Areas where chests can be placed. Some maps allow placing chests anywhere, while
 
 If you choose to submit your map, include a screenshot of it in the exported map's folder. It should have an aspect ratio of 3:2 (screenshot 600x400px is suggested).
 You can take a screenshot easily by doing the following:
-1. Press F1 on your keyboard to hide the HUD
-2. Press F2 on your keyboard to hide the chat log
-3. *Optional:* Press R on your keyboard to enable unlimited viewing range if part of the map is not rendered
+1. Hide the HUD. By default <kbd>F1</kbd> does that.
+2. Hide the chat log. By default <kbd>F2</kbd> does that.
+3. *(Optional)* Enable unlimited view range if all important parts of the map cannot be seen. By default <kbd>R</kbd> does that.
 4. Try to find a good view that shows most of the map
-5. Press F12 on your keyboard to take a screenshot
-6. You can find your screenshot inside `\[Minetest folder]/screenshots`
-
+5. Take a screenshot **from Minetest**. By default F12 does that.
+6. You can find the screenshot in `screenshots` folder in the Minetest data folder unless you have changed the path in settings.
 Crop the screenshot into the aspect ratio mentioned above using a tool of your choice, and put the screenshot inside your exported map's folder. It should be named `screenshot.png`.

--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -37,9 +37,9 @@
 - Don't forget to add
 	- Team chests
 	- Flags. Place it, then right-click it to choose flag color.
-	- "Indestructible Barrier Glass" (ctf_map:ind_glass) around the edge of the world.
-	- "Indestructible Red Barrier Glass" (ctf_map:ind_glass_red) for the build-time wall.
-	- "Indestructible Red Barrier Stone" (ctf_map:ind_stone_red) for underground build-time wall.
+	- "Indestructible Barrier Glass" (`ctf_map:ind_glass`) around the edge of the world.
+	- "Indestructible Red Barrier Glass" (`ctf_map:ind_glass_red`) for the build-time wall.
+	- "Indestructible Red Barrier Stone" (`ctf_map:ind_stone_red`) for underground build-time wall.
 
 ### 5. Fill out information about the map
 
@@ -119,5 +119,11 @@ Areas where chests can be placed. Some maps allow placing chests anywhere, while
 ### 8. Screenshot
 
 If you choose to submit your map, include a screenshot of it in the exported map's folder. It should have an aspect ratio of 3:2 (screenshot 600x400px is suggested).
+You can take a screenshot easily by doing the following:
+1. Press F1 on your keyboard to hide the HUD
+2. Press F2 on your keyboard to hide the chat log
+3. Try to find a good view that shows most of the map
+4. Press F12 on your keyboard to take a screenshot
+5. You can find your screenshot inside `\[Minetest folder]/screenshots`
 
-It should be named `screenshot.png`.
+Crop the screenshot into the aspect ratio mentioned above using a tool of your choice, and put the screenshot inside your exported map's folder. It should be named `screenshot.png`.

--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -123,7 +123,7 @@ You can take a screenshot easily by doing the following:
 1. Hide the HUD. By default <kbd>F1</kbd> does that.
 2. Hide the chat log. By default <kbd>F2</kbd> does that.
 3. Try to find a good view that shows most of the map.
-4. *(Optional)* Enable unlimited view range if important parts of the map cannot be seen. By default <kbd>R</kbd> does that.
+4. *(Optional)* Increase your view range if important parts of the map cannot be seen. By default the <kbd>=</kbd> (or <kbd>+</kbd>) and <kbd>-</kbd> keys do that.
 5. Take a screenshot **from Minetest**. By default <kbd>F12</kbd> does that.
 6. You can find the screenshot in `[Minetest folder]/screenshots` unless you have changed the path in settings.
 Crop the screenshot into the aspect ratio mentioned above using a tool of your choice, and put the screenshot inside your exported map's folder. It should be named `screenshot.png`.

--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -125,5 +125,5 @@ You can take a screenshot easily by doing the following:
 3. Try to find a good view that shows most of the map.
 4. *(Optional)* Enable unlimited view range if important parts of the map cannot be seen. By default <kbd>R</kbd> does that.
 5. Take a screenshot **from Minetest**. By default <kbd>F12</kbd> does that.
-6. You can find the screenshot in `\[Minetest folder]/screenshots` unless you have changed the path in settings.
+6. You can find the screenshot in `[Minetest folder]/screenshots` unless you have changed the path in settings.
 Crop the screenshot into the aspect ratio mentioned above using a tool of your choice, and put the screenshot inside your exported map's folder. It should be named `screenshot.png`.

--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -122,8 +122,8 @@ If you choose to submit your map, include a screenshot of it in the exported map
 You can take a screenshot easily by doing the following:
 1. Hide the HUD. By default <kbd>F1</kbd> does that.
 2. Hide the chat log. By default <kbd>F2</kbd> does that.
-3. *(Optional)* Enable unlimited view range if all important parts of the map cannot be seen. By default <kbd>R</kbd> does that.
-4. Try to find a good view that shows most of the map
-5. Take a screenshot **from Minetest**. By default F12 does that.
-6. You can find the screenshot in `screenshots` folder in the Minetest data folder unless you have changed the path in settings.
+3. Try to find a good view that shows most of the map
+4. *(Optional)* Enable unlimited view range if important parts of the map cannot be seen. By default <kbd>R</kbd> does that.
+5. Take a screenshot **from Minetest**. By default <kbd>F12</kbd> does that.
+6. You can find the screenshot in `\[Minetest folder]/screenshots` unless you have changed the path in settings.
 Crop the screenshot into the aspect ratio mentioned above using a tool of your choice, and put the screenshot inside your exported map's folder. It should be named `screenshot.png`.

--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -122,7 +122,7 @@ If you choose to submit your map, include a screenshot of it in the exported map
 You can take a screenshot easily by doing the following:
 1. Hide the HUD. By default <kbd>F1</kbd> does that.
 2. Hide the chat log. By default <kbd>F2</kbd> does that.
-3. Try to find a good view that shows most of the map
+3. Try to find a good view that shows most of the map.
 4. *(Optional)* Enable unlimited view range if important parts of the map cannot be seen. By default <kbd>R</kbd> does that.
 5. Take a screenshot **from Minetest**. By default <kbd>F12</kbd> does that.
 6. You can find the screenshot in `\[Minetest folder]/screenshots` unless you have changed the path in settings.

--- a/mods/ctf/ctf_map/README.md
+++ b/mods/ctf/ctf_map/README.md
@@ -122,8 +122,9 @@ If you choose to submit your map, include a screenshot of it in the exported map
 You can take a screenshot easily by doing the following:
 1. Press F1 on your keyboard to hide the HUD
 2. Press F2 on your keyboard to hide the chat log
-3. Try to find a good view that shows most of the map
-4. Press F12 on your keyboard to take a screenshot
-5. You can find your screenshot inside `\[Minetest folder]/screenshots`
+3. *Optional:* Press R on your keyboard to enable unlimited viewing range if part of the map is not rendered
+4. Try to find a good view that shows most of the map
+5. Press F12 on your keyboard to take a screenshot
+6. You can find your screenshot inside `\[Minetest folder]/screenshots`
 
 Crop the screenshot into the aspect ratio mentioned above using a tool of your choice, and put the screenshot inside your exported map's folder. It should be named `screenshot.png`.


### PR DESCRIPTION
Add more details to the instructions about taking a screenshot to make the process easier and ensure screenshots with better quality. 
`` are also added to the block string names to make them more visually appealing. 