### PR TITLE
Add stone swords to blacklist

### DIFF
--- a/mods/ctf/ctf_teams/team_chest.lua
+++ b/mods/ctf/ctf_teams/team_chest.lua
@@ -1,6 +1,7 @@
 local blacklist = {
 	"default:pine_needles",
 	".*leaves$",
+	"ctf_melee:sword_stone"
 }
 
 local function get_chest_access(name)


### PR DESCRIPTION
Blacklist stone swords from going in the team chest, since they don't serve a purpose.

https://discord.com/channels/447819017391046687/448136308108296213/1105827145902731365