### PR TITLE
Adding filter to `/me`

### DIFF
--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -45,6 +45,10 @@ end
 
 minetest.override_chatcommand("me", {
 	func = function(name, param)
+		if filter and not filter.check_message(name, message) then
+			filter.on_violation(name, message)
+			return false
+		end
 		minetest.log("action", string.format("[CHAT] ME from %s: %s", name, param))
 
 		if ctf_chat.send_me(name, param) then

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -45,6 +45,8 @@ end
 
 minetest.override_chatcommand("me", {
 	func = function(name, param)
+		local message = param:match("^(.+)$")
+
 		if filter and not filter.check_message(name, message) then
 			filter.on_violation(name, message)
 			return false


### PR DESCRIPTION
So I had a look at the chat code, trying to find a way to add the filter to the `/me` command. I noticed that it doesn't have a swear filter, similar to how `/msg` is structured. I did this, but can't test it. Likewise, I think (I may be highly wrong) that the swear mod is a private mod that is not publicly available and that the "filters" can only be tested when the filter exists?
> I have no clue of what I am doing.