### PR TITLE
Fix poison nades disappearing

### DIFF
--- a/mods/ctf/ctf_modebase/mod.conf
+++ b/mods/ctf/ctf_modebase/mod.conf
@@ -1,2 +1,2 @@
 name = ctf_modebase
-depends = ctf_api, ctf_core, ctf_teams, ctf_gui, ctf_map, ctf_healing, crafting, mhud, default, binoculars, dropondie
+depends = ctf_api, ctf_core, ctf_teams, ctf_gui, ctf_map, ctf_healing, crafting, mhud, default, binoculars

--- a/mods/ctf/ctf_modebase/respawn_delay.lua
+++ b/mods/ctf/ctf_modebase/respawn_delay.lua
@@ -15,7 +15,9 @@ minetest.register_entity("ctf_modebase:respawn_movement_freezer", {
 
 local function finish_respawn(player)
 	local pname = player:get_player_name()
-	dropondie.drop_all(player)
+	if minetest.get_modpath("dropondie") then
+        dropondie.drop_all(player)
+    end
 	if respawn_delay[pname].state == true then
 		hud:remove(pname, "left")
 	end

--- a/mods/ctf/ctf_modebase/respawn_delay.lua
+++ b/mods/ctf/ctf_modebase/respawn_delay.lua
@@ -15,7 +15,7 @@ minetest.register_entity("ctf_modebase:respawn_movement_freezer", {
 
 local function finish_respawn(player)
 	local pname = player:get_player_name()
-
+	dropondie.drop_all(player)
 	if respawn_delay[pname].state == true then
 		hud:remove(pname, "left")
 	end


### PR DESCRIPTION
Drop all items before respawn to clear bugged poison smoke nades in inventory if they are thrown near enemy base and then the player dies before they land.