### PR TITLE
Allow medkit healing within stairs, doors, and fences

### DIFF
--- a/mods/ctf/ctf_combat/ctf_healing/medkit.lua
+++ b/mods/ctf/ctf_combat/ctf_healing/medkit.lua
@@ -54,8 +54,9 @@ local function medkit_heal(playername)
 		local node_0 = minetest.get_node(pos).name
 		local node_1 = minetest.get_node(pos:offset(0, 1, 0)).name
 
-		if (not node_0:match("slab") and node_0 ~= "default:snow" and minetest.registered_nodes[node_0].walkable) or
-		minetest.registered_nodes[node_1].walkable then
+		if (not node_0:match("slab") and not node_0:match("stair") and not node_0:match("door") and
+        not node_0:match("fence") and node_0 ~= "default:snow" and minetest.registered_nodes[node_0].walkable) or
+	    (minetest.registered_nodes[node_1].walkable and not node_1:match("door") and not node_1:match("fence")) then
 			return stop_medkit_heal(playername, "You can't heal while inside blocks")
 		end
 
@@ -100,8 +101,9 @@ local function start_medkit_heal(playername)
 	local node_0 = minetest.get_node(pos).name
 	local node_1 = minetest.get_node(pos:offset(0, 1, 0)).name
 
-	if (not node_0:match("slab") and node_0 ~= "default:snow" and minetest.registered_nodes[node_0].walkable) or
-	minetest.registered_nodes[node_1].walkable then
+	if (not node_0:match("slab") and not node_0:match("stair") and not node_0:match("door") and
+	not node_0:match("fence") and node_0 ~= "default:snow" and minetest.registered_nodes[node_0].walkable) or
+	(minetest.registered_nodes[node_1].walkable and not node_1:match("door") and not node_1:match("fence")) then
 		return hud_events.new(playername, {
 			text = "You can't heal inside blocks",
 			color = "danger",


### PR DESCRIPTION
Add check to not stop healing if in stairs, doors, or fences