### PR TITLE
Make /t command easier

### DIFF
--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -116,11 +116,11 @@ end)
 minetest.register_on_chat_message(function(name, message)
 	local check_message = string.sub(message, 1, 1)
 
-	if message:len() < 2 and check_message == "!" then
+	if message:len() < 2 and check_message == ":" then
 		return false
 	end
 
-	if check_message == "!" then
+	if check_message == ":" then
 		local message = string.sub(message, 2, string.len(message))
 		local tname = ctf_teams.get(name)
 		if tname then

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -116,11 +116,11 @@ end)
 minetest.register_on_chat_message(function(name, message)
 	local check_message = string.sub(message, 1, 1)
 
-	if message:len() < 2 and check_message == ":" then
+	if message:len() < 2 and check_message == ";" then
 		return false
 	end
 
-	if check_message == ":" then
+	if check_message == ";" then
 		local message = string.sub(message, 2, string.len(message))
 		local tname = ctf_teams.get(name)
 		if tname then

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -114,11 +114,13 @@ minetest.register_on_mods_loaded(function()
 end)
 
 minetest.register_on_chat_message(function(name, message)
-	if message:len() < 2 and string.sub(message, 1, 1) == "!" then
+	local check_message = string.sub(message, 1, 1)
+
+	if message:len() < 2 and check_message == "!" then
 		return false
 	end
 
-	if string.sub(message, 1, 1) == "!" then
+	if check_message == "!" then
 		local message = string.sub(message, 2, string.len(message))
 		local tname = ctf_teams.get(name)
 		if tname then

--- a/mods/ctf/ctf_modebase/mode_vote.lua
+++ b/mods/ctf/ctf_modebase/mode_vote.lua
@@ -29,7 +29,12 @@ local function show_modechoose_form(player)
 	vote_setting = ctf_settings.settings["ctf_modebase:default_vote_"..new_mode]._list_map[tonumber(vote_setting)]
 
 	if vote_setting ~= "ask" then
-		minetest.after(0, player_vote, player, vote_setting)
+		minetest.after(0, function()
+			if not minetest.get_player_by_name(player) then return end
+
+			player_vote(player, vote_setting)
+		end)
+
 		return
 	end
 


### PR DESCRIPTION
I wanted to make it so where the /t command could become easier. The command would be activated by putting a semicolon before the message.

This is so mobile players would have easier functionality when talking to their own team specifically.

All that I did was copy & paste the code from the /t and changed it to fit what I had wanted.