### PR TITLE
Fix water flow in barrier removal

### DIFF
--- a/mods/ctf/ctf_map/map_functions.lua
+++ b/mods/ctf/ctf_map/map_functions.lua
@@ -124,7 +124,6 @@ function ctf_map.remove_barrier(mapmeta, pos2, callback)
 		return d
 	end, function(d)
 		vm:set_data(d)
-		vm:calc_lighting()
 		vm:update_liquids()
 		vm:write_to_map(false)
 		callback()


### PR DESCRIPTION
This PR fixes water flows by replacing barriers with water source if there are two water sources as their neighbor.

This PR is ready for review. Some maps not extending their border into the ocean (e.g. Desert Spikes) can now be fixed.

### The logic

The code only works on barriers that should be replaced by air (i.e. [`replacement_id == ID_AIR`](https://github.com/MT-CTF/capturetheflag/blob/8720280f2d3ef8ba70c9517bf906ded3bf885052/mods/ctf/ctf_map/map_functions.lua#L92)). On each such node, four neighbor nodes of the same Y-coordinate (i.e. z +/- 1, x +/- 1) are listed and checked. If two of them are water sources, the current barrier will be replaced by water source instead of air.

Due to the above code, the [`d[vi] == ID_AIR`](https://github.com/MT-CTF/capturetheflag/blob/f44e0ed14dc22f794c6e2f94d135cc867d062d81/mods/ctf/ctf_map/map_functions.lua#L97) check is no longer necessary and is [removed](https://github.com/MT-CTF/capturetheflag/blob/8720280f2d3ef8ba70c9517bf906ded3bf885052/mods/ctf/ctf_map/map_functions.lua#L117) in this PR.

### Gallery

Before ([`f44e0ed`](https://github.com/MT-CTF/capturetheflag/commit/f44e0ed14dc22f794c6e2f94d135cc867d062d81)):

![screenshot_20230810_085204](https://github.com/MT-CTF/capturetheflag/assets/55009343/3b040ae7-7da6-4878-8a01-64e0fbe60b6a)

After:

![screenshot_20230810_084439](https://github.com/MT-CTF/capturetheflag/assets/55009343/1a5074d5-f5aa-4658-80df-78ca2aa8d337)
