### PR TITLE
Remove new line when map.hint isn't nil but is empty

### DIFF
--- a/mods/ctf/ctf_map/map_functions.lua
+++ b/mods/ctf/ctf_map/map_functions.lua
@@ -1,7 +1,7 @@
 function ctf_map.announce_map(map)
 	local msg = (minetest.colorize("#fcdb05", "Map: ") .. minetest.colorize("#f49200", map.name) ..
 	minetest.colorize("#fcdb05", " by ") .. minetest.colorize("#f49200", map.author))
-	if map.hint and map.hint ~= ""then
+	if map.hint and map.hint ~= "" then
 		msg = msg .. "\n" .. minetest.colorize("#f49200", map.hint)
 	end
 	minetest.chat_send_all(msg)

--- a/mods/ctf/ctf_map/map_functions.lua
+++ b/mods/ctf/ctf_map/map_functions.lua
@@ -1,7 +1,7 @@
 function ctf_map.announce_map(map)
 	local msg = (minetest.colorize("#fcdb05", "Map: ") .. minetest.colorize("#f49200", map.name) ..
 	minetest.colorize("#fcdb05", " by ") .. minetest.colorize("#f49200", map.author))
-	if map.hint then
+	if map.hint and map.hint ~= ""then
 		msg = msg .. "\n" .. minetest.colorize("#f49200", map.hint)
 	end
 	minetest.chat_send_all(msg)


### PR DESCRIPTION
The original check of empty map hint only checks for a `nil` map hint. This PR also checks for an empty (i.e. `""`) map hint.

This PR is ready for review.

Before:
![Screenshot_20230810_095020](https://github.com/MT-CTF/capturetheflag/assets/55009343/bbead661-d707-43c8-bde5-d248768968d9)

After:
![Screenshot_20230810_094843](https://github.com/MT-CTF/capturetheflag/assets/55009343/26d607f1-bd6a-49d6-85f3-f5779b8bb3fc)

