### PR TITLE
Drop the nade with illegal explode points if the thrower is dead

### DIFF
--- a/mods/pvp/grenades/grenades.lua
+++ b/mods/pvp/grenades/grenades.lua
@@ -166,7 +166,7 @@ local register_smoke_grenade = function(name, description, image, damage)
 						if distance_from_flag <= 15 and (damage or pteam == flagteam) then
 							minetest.chat_send_player(pname, "You can't explode smoke grenades so close to a flag!")
 							if player:get_hp() <= 0 then
-								-- Drop the nade at its explode point if the thrower is head
+								-- Drop the nade at its explode point if the thrower is dead
 								-- Fixes https://github.com/MT-CTF/capturetheflag/issues/1160
 								minetest.add_item(pos, ItemStack("grenades:"..name))
 							else

--- a/mods/pvp/grenades/grenades.lua
+++ b/mods/pvp/grenades/grenades.lua
@@ -165,7 +165,15 @@ local register_smoke_grenade = function(name, description, image, damage)
 						local distance_from_flag = vector.distance(pos, team.flag_pos)
 						if distance_from_flag <= 15 and (damage or pteam == flagteam) then
 							minetest.chat_send_player(pname, "You can't explode smoke grenades so close to a flag!")
-							player:get_inventory():add_item("main", "grenades:"..name)
+							if player:get_hp() <= 0 then
+								-- Drop the nade at its explode point if the thrower is head
+								-- Fixes https://github.com/MT-CTF/capturetheflag/issues/1160
+								minetest.add_item(pos, ItemStack("grenades:"..name))
+							else
+								-- Add the nade back into the thrower's inventory
+								player:get_inventory():add_item("main", "grenades:"..name)
+							end
+							
 							return
 						elseif damage and distance_from_flag <= 26 then
 							duration_multiplier = 0.5

--- a/mods/pvp/grenades/grenades.lua
+++ b/mods/pvp/grenades/grenades.lua
@@ -173,7 +173,6 @@ local register_smoke_grenade = function(name, description, image, damage)
 								-- Add the nade back into the thrower's inventory
 								player:get_inventory():add_item("main", "grenades:"..name)
 							end
-							
 							return
 						elseif damage and distance_from_flag <= 26 then
 							duration_multiplier = 0.5


### PR DESCRIPTION
Fixes #1160

This PR add checks to player HP before adding nades back to thrower's inventory. If the player is head, the nade is dropped at its explode point.

This PR is ready for review.