### PR TITLE
Fix non-diagonal borders water detect

### DIFF
--- a/mods/ctf/ctf_map/map_functions.lua
+++ b/mods/ctf/ctf_map/map_functions.lua
@@ -74,7 +74,7 @@ function ctf_map.remove_barrier(mapmeta, pos2, callback)
 
 	-- Shave off ~0.1 seconds from the main loop
 	minetest.handle_async(function(d, p1, p2, barrier_nodes, t)
-		local mod = {}
+		local mod = {} -- All its contents will be recreated in the loop
 		local Nx = p2.x - p1.x + 1
 		local Ny = p2.y - p1.y + 1
 		local ID_IGNORE = minetest.CONTENT_IGNORE

--- a/mods/ctf/ctf_map/map_functions.lua
+++ b/mods/ctf/ctf_map/map_functions.lua
@@ -74,6 +74,7 @@ function ctf_map.remove_barrier(mapmeta, pos2, callback)
 
 	-- Shave off ~0.1 seconds from the main loop
 	minetest.handle_async(function(d, p1, p2, barrier_nodes, t)
+		local mod = table.copy(d)
 		local Nx = p2.x - p1.x + 1
 		local Ny = p2.y - p1.y + 1
 		local ID_IGNORE = minetest.CONTENT_IGNORE
@@ -107,7 +108,7 @@ function ctf_map.remove_barrier(mapmeta, pos2, callback)
 									end
 								end
 							end
-							d[vi] = replacement_this
+							mod[vi] = replacement_this
 							done = true
 							break
 						end
@@ -115,13 +116,13 @@ function ctf_map.remove_barrier(mapmeta, pos2, callback)
 
 					-- Avoid changing nodes players placed during async
 					if not done then
-						d[vi] = ID_IGNORE
+						mod[vi] = ID_IGNORE
 					end
 				end
 			end
 		end
 
-		return d
+		return mod
 	end, function(d)
 		vm:set_data(d)
 		vm:update_liquids()

--- a/mods/ctf/ctf_map/map_functions.lua
+++ b/mods/ctf/ctf_map/map_functions.lua
@@ -74,7 +74,7 @@ function ctf_map.remove_barrier(mapmeta, pos2, callback)
 
 	-- Shave off ~0.1 seconds from the main loop
 	minetest.handle_async(function(d, p1, p2, barrier_nodes, t)
-		local mod = table.copy(d)
+		local mod = {}
 		local Nx = p2.x - p1.x + 1
 		local Ny = p2.y - p1.y + 1
 		local ID_IGNORE = minetest.CONTENT_IGNORE


### PR DESCRIPTION
Sorry for not testing the previous PR #1199 on a variety of maps. This PR fixes the behavior of water checking on non-diagonal maps (i.e. only either +/- X or +/- Z touches water).

In the original code, unmodified nodes are changed into ignore (i.e. do not modify them on map). However, because we were iterating the contents one by one, this lead to failed water detection as at least one of the border's neighbor would be converted into ignore before the detection occurs. In Water Academy, this bug wasn't found because all borders have four neighbors and can tolerate this kind of bug. ~~This PR fixes this bug by copying the table of content IDs and work on the copy instead. The new copy is called `mod`, stands for "modifications".~~

(New in [`ca43590`](https://github.com/MT-CTF/capturetheflag/pull/1202/commits/ca4359049d406cf1f6a78bdcc7bbb322d854d964)) A new empty table called `mod` (stands for "modifications") is created. As we iterate through all the elements of the original `d` table, all the latter's key will be recreated with the new contents. In compare to the `table.copy(d)` approach in my previous commits, this can speed up the process of barrier removal.

This PR is ready for review.