### PR TITLE
Make summary formspec more "mobile-friendly"

### DIFF
--- a/mods/ctf/ctf_modebase/summary.lua
+++ b/mods/ctf/ctf_modebase/summary.lua
@@ -286,7 +286,7 @@ function ctf_modebase.summary.show_gui_sorted(name, rankings, special_rankings, 
 	if formdef.winner then
 		formspec.elements.winner = {
 			type = "label",
-			pos = {4, 0.5},
+			pos = {5, 0.5},
 			label = formdef.winner,
 		}
 	end


### PR DESCRIPTION
This pull request spaces the match duration and the winner out slightly so the duration is no longer blocked by the winner when viewing from mobile or a small screen.