### PR TITLE
Changes to HP markers and miscellaneous additions to `random_messages`

### DIFF
--- a/mods/ctf/ctf_modebase/markers.lua
+++ b/mods/ctf/ctf_modebase/markers.lua
@@ -60,31 +60,6 @@ local function add_marker(pname, pteam, message, pos, owner)
 	end
 end
 
-local function check_pointed_entity(pointed, message, pos)
-	local concat
-	local obj = pointed.ref
-	local entity = obj:get_luaentity()
-	-- If object is a player, append player name to display text
-	-- Else if obj is item entity, append item description and count to str.
-	if obj:is_player() then
-		concat = obj:get_player_name()
-	elseif entity then
-		if entity.name == "__builtin:item" then
-			local stack = ItemStack(entity.itemstring)
-			local itemdef = minetest.registered_items[stack:get_name()]
-			-- Fallback to itemstring if description doesn't exist
-			-- Only use first line of itemstring
-			concat = string.match(itemdef.description or entity.itemstring, "^([^\n]+)")
-			concat = concat .. " " .. stack:get_count()
-		end
-	end
-	pos = obj:get_pos()
-	if concat then
-		message = message .. " <" .. concat .. ">"
-	end
-	return message, pos
-end
-
 function ctf_modebase.markers.remove(pname, no_notify)
 	if markers[pname] then
 		markers[pname].timer:cancel()
@@ -207,23 +182,34 @@ local function marker_func(name, param, specific_player, hpmarker)
 		else
 			pos = player:get_pos()
 		end
-		if pointed then
-			if pointed.type == "object" then
-				message, pos = check_pointed_entity(pointed, message, pos)
-			end
-		end
-
-		-- If the player places a marker upon death, it will resort to the below
-		if player:get_hp() == 0 then
-			message = string.format("m <%s> died here", name)
-		end
 	else
 		if not pointed then
 			return false, "Can't find anything to mark, too far away!"
 		end
 		message = string.format("m [%s]: %s", name, param)
+
 		if pointed.type == "object" then
-			message, pos = check_pointed_entity(pointed, message, pos)
+			local concat
+			local obj = pointed.ref
+			local entity = obj:get_luaentity()
+			-- If object is a player, append player name to display text
+			-- Else if obj is item entity, append item description and count to str.
+			if obj:is_player() then
+				concat = obj:get_player_name()
+			elseif entity then
+				if entity.name == "__builtin:item" then
+					local stack = ItemStack(entity.itemstring)
+					local itemdef = minetest.registered_items[stack:get_name()]
+					-- Fallback to itemstring if description doesn't exist
+					-- Only use first line of itemstring
+					concat = string.match(itemdef.description or entity.itemstring, "^([^\n]+)")
+					concat = concat .. " " .. stack:get_count()
+				end
+			end
+				pos = obj:get_pos()
+			if concat then
+				message = message .. " <" .. concat .. ">"
+			end
 		else
 			pos = pointed.under
 		end
@@ -338,4 +324,3 @@ minetest.register_globalstep(function(dtime)
 		end
 	end
 end)
-

--- a/mods/ctf/ctf_modebase/markers.lua
+++ b/mods/ctf/ctf_modebase/markers.lua
@@ -338,4 +338,3 @@ minetest.register_globalstep(function(dtime)
 		end
 	end
 end)
-

--- a/mods/ctf/ctf_modebase/markers.lua
+++ b/mods/ctf/ctf_modebase/markers.lua
@@ -216,6 +216,10 @@ local function marker_func(name, param, specific_player, hpmarker)
 		-- If the player places a marker upon death, it will resort to the below
 		if player:get_hp() == 0 then
 			message = string.format("m <%s> died here", name)
+			if param ~= "Look here!" then message = string.format(
+				"m [%s]: %s", name, param
+			)
+			end
 		end
 	else
 		if not pointed then

--- a/mods/ctf/ctf_modebase/markers.lua
+++ b/mods/ctf/ctf_modebase/markers.lua
@@ -60,7 +60,7 @@ local function add_marker(pname, pteam, message, pos, owner)
 	end
 end
 
-local function check_pointed_entity(pointed, message, pos)
+local function check_pointed_entity(pointed, message)
 	local concat
 	local obj = pointed.ref
 	local entity = obj:get_luaentity()
@@ -78,7 +78,7 @@ local function check_pointed_entity(pointed, message, pos)
 			concat = concat .. " " .. stack:get_count()
 		end
 	end
-	pos = obj:get_pos()
+	local pos = obj:get_pos()
 	if concat then
 		message = message .. " <" .. concat .. ">"
 	end
@@ -223,7 +223,7 @@ local function marker_func(name, param, specific_player, hpmarker)
 		end
 		message = string.format("m [%s]: %s", name, param)
 		if pointed.type == "object" then
-			message, pos = check_pointed_entity(pointed, message, pos)
+			message, pos = check_pointed_entity(pointed, message)
 		else
 			pos = pointed.under
 		end

--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -77,7 +77,7 @@ function random_messages.read_messages()
 		"Use /leagues to list leagues and the placement needed to get to them.",
 		"Use /mhp or left/right click while holding the zoom key (default: Z)"
 		.. "pointed towards your feet to place an HP marker.",
-		"Use /map to print the current map name and map author.",
+		"Use /map to print the current map name and its author.",
 		"To check someone's ranking in all modes, use /rank mode:all <player_name>",
 	}
 end

--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -75,7 +75,7 @@ function random_messages.read_messages()
 		"Use /mp <player> to send a marker to a specific teammate",
 		"To check someone's league in all modes, use /league <player>",
 		"Use /leagues to list leagues and the placement needed to get to them.",
-		"To place an HP marker run /mhp or left/right click while holding the zoom key (default: Z) "..
+		"To place an HP marker, run /mhp or left/right click while holding the zoom key (default: Z) "..
 			"and looking at your feet",
 		"Use /map to print the current map name and its author.",
 		"To check someone's ranking in all modes, use /rank mode:all <player_name>",

--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -75,8 +75,8 @@ function random_messages.read_messages()
 		"Use /mp <player> to send a marker to a specific teammate",
 		"To check someone's league in all modes, use /league <player>",
 		"Use /leagues to list leagues and the placement needed to get to them.",
-		"Use /mhp or left/right click while holding the zoom key (default: Z)"
-		.. "pointed towards your feet to place an HP marker.",
+		"To place an HP marker run /mhp or left/right click while holding the zoom key (default: Z) "..
+			"and looking at your feet",
 		"Use /map to print the current map name and its author.",
 		"To check someone's ranking in all modes, use /rank mode:all <player_name>",
 	}

--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -163,4 +163,3 @@ local register_chatcommand_table = {
 
 minetest.register_chatcommand("random_messages", register_chatcommand_table)
 minetest.register_chatcommand("rmessages", register_chatcommand_table)
-

--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -75,7 +75,8 @@ function random_messages.read_messages()
 		"Use /mp <player> to send a marker to a specific teammate",
 		"To check someone's league in all modes, use /league <player>",
 		"Use /leagues to list leagues and the placement needed to get to them.",
-		"Use /mhp or left/right click while holding the zoom key (default: Z) pointed towards your feet to place an HP marker.",
+		"Use /mhp or left/right click while holding the zoom key (default: Z)"
+		.. "pointed towards your feet to place an HP marker.",
 		"Use /map to print the current map name and map author.",
 		"To check someone's ranking in all modes, use /rank mode:all <player_name>",
 	}

--- a/mods/other/random_messages/init.lua
+++ b/mods/other/random_messages/init.lua
@@ -75,6 +75,9 @@ function random_messages.read_messages()
 		"Use /mp <player> to send a marker to a specific teammate",
 		"To check someone's league in all modes, use /league <player>",
 		"Use /leagues to list leagues and the placement needed to get to them.",
+		"Use /mhp or left/right click while holding the zoom key (default: Z) pointed towards your feet to place an HP marker.",
+		"Use /map to print the current map name and map author.",
+		"To check someone's ranking in all modes, use /rank mode:all <player_name>",
 	}
 end
 
@@ -160,3 +163,4 @@ local register_chatcommand_table = {
 
 minetest.register_chatcommand("random_messages", register_chatcommand_table)
 minetest.register_chatcommand("rmessages", register_chatcommand_table)
+


### PR DESCRIPTION
# Changes
- HP markers now append itemstrings.
- When HP is `0`, i.e., when a player places a marker upon death, is shows a different message: `"<player> died here"`
- Adds random messages about `/mhp`/HP markers, `/map` command, `mode:all` addition to the `/r` command.