### PR TITLE
Send messages to players with autovoting on

### DIFF
--- a/mods/ctf/ctf_modebase/mode_vote.lua
+++ b/mods/ctf/ctf_modebase/mode_vote.lua
@@ -32,6 +32,9 @@ local function show_modechoose_form(player)
 		minetest.after(0, function()
 			if not minetest.get_player_by_name(player) then return end
 
+			minetest.chat_send_player(player,
+				string.format("Voting for " .. new_mode .. ". Automatic vote: " .. vote_setting .. "\n" ..
+				"To change the automatic vote settings, go to the \"Settings\" tab of your inventory."))
 			player_vote(player, vote_setting)
 		end)
 


### PR DESCRIPTION
This PR adds code to send a message to players with autovoting on when a vote is started. The message tells the player the current setting, and reminds them how to change it.

This PR is ready for review.