### PR TITLE
Prevent crash if missing barriers file

### DIFF
--- a/mods/ctf/ctf_map/map_meta.lua
+++ b/mods/ctf/ctf_map/map_meta.lua
@@ -162,7 +162,7 @@ function ctf_map.load_map_meta(idx, dirname)
 		if tonumber(meta:get("map_version")) > 2 then
 			local filename = ctf_map.maps_dir .. dirname .. "/barriers.data"
 			local f = io.open(filename, "rb")
-		
+			
 			if f ~= nil then
 				local barriers = f:read("*all")
 				

--- a/mods/ctf/ctf_map/map_meta.lua
+++ b/mods/ctf/ctf_map/map_meta.lua
@@ -191,7 +191,7 @@ function ctf_map.load_map_meta(idx, dirname)
 					if ctf_core.settings.server_mode ~= "mapedit" then
 						assert(false, "Map "..dirname.." has a corrupted barriers file. Re-save map to fix")
 					end
-					
+
 					minetest.log("error", "Map "..dirname.." has a corrupted barriers file. Re-save map to fix")
 				end
 			else

--- a/mods/ctf/ctf_map/map_meta.lua
+++ b/mods/ctf/ctf_map/map_meta.lua
@@ -162,21 +162,21 @@ function ctf_map.load_map_meta(idx, dirname)
 		if tonumber(meta:get("map_version")) > 2 then
 			local filename = ctf_map.maps_dir .. dirname .. "/barriers.data"
 			local f = io.open(filename, "rb")
-			
+
 			if f ~= nil then
 				local barriers = f:read("*all")
-				
+
 				f:close()
-		
+
 				assert(barriers and barriers ~= "")
-		
+
 				barriers = minetest.deserialize(minetest.decompress(barriers, "deflate"))
-		
+
 				if barriers then
 					for _, barrier_area in pairs(barriers) do
 						barrier_area.pos1 = vector.add(barrier_area.pos1, offset)
 						barrier_area.pos2 = vector.add(barrier_area.pos2, offset)
-		
+
 						for i = 1, barrier_area.max do
 							if not barrier_area.reps[i] then
 								barrier_area.reps[i] = minetest.CONTENT_IGNORE
@@ -185,13 +185,13 @@ function ctf_map.load_map_meta(idx, dirname)
 							end
 						end
 					end
-		
+
 					map.barriers = barriers
 				else
 					if ctf_core.settings.server_mode ~= "mapedit" then
 						assert(false, "Map "..dirname.." has a corrupted barriers file. Re-save map to fix")
 					end
-		
+					
 					minetest.log("error", "Map "..dirname.." has a corrupted barriers file. Re-save map to fix")
 				end
 			else

--- a/mods/ctf/ctf_map/map_meta.lua
+++ b/mods/ctf/ctf_map/map_meta.lua
@@ -160,37 +160,42 @@ function ctf_map.load_map_meta(idx, dirname)
 			enable_shadows = tonumber(meta:get("enable_shadows") or "0.26"),
 		}
 		if tonumber(meta:get("map_version")) > 2 then
-			local f = assert(io.open(ctf_map.maps_dir .. dirname .. "/barriers.data", "rb"))
-
-			local barriers = f:read("*all")
-
-			f:close()
-
-			assert(barriers and barriers ~= "")
-
-			barriers = minetest.deserialize(minetest.decompress(barriers, "deflate"))
-
-			if barriers then
-				for _, barrier_area in pairs(barriers) do
-					barrier_area.pos1 = vector.add(barrier_area.pos1, offset)
-					barrier_area.pos2 = vector.add(barrier_area.pos2, offset)
-
-					for i = 1, barrier_area.max do
-						if not barrier_area.reps[i] then
-							barrier_area.reps[i] = minetest.CONTENT_IGNORE
-						else
-							barrier_area.reps[i] = minetest.get_content_id(barrier_area.reps[i])
+			local filename = ctf_map.maps_dir .. dirname .. "/barriers.data"
+			local f = io.open(filename, "rb")
+		
+			if f ~= nil then
+				local barriers = f:read("*all")
+				
+				f:close()
+		
+				assert(barriers and barriers ~= "")
+		
+				barriers = minetest.deserialize(minetest.decompress(barriers, "deflate"))
+		
+				if barriers then
+					for _, barrier_area in pairs(barriers) do
+						barrier_area.pos1 = vector.add(barrier_area.pos1, offset)
+						barrier_area.pos2 = vector.add(barrier_area.pos2, offset)
+		
+						for i = 1, barrier_area.max do
+							if not barrier_area.reps[i] then
+								barrier_area.reps[i] = minetest.CONTENT_IGNORE
+							else
+								barrier_area.reps[i] = minetest.get_content_id(barrier_area.reps[i])
+							end
 						end
 					end
+		
+					map.barriers = barriers
+				else
+					if ctf_core.settings.server_mode ~= "mapedit" then
+						assert(false, "Map "..dirname.." has a corrupted barriers file. Re-save map to fix")
+					end
+		
+					minetest.log("error", "Map "..dirname.." has a corrupted barriers file. Re-save map to fix")
 				end
-
-				map.barriers = barriers
 			else
-				if ctf_core.settings.server_mode ~= "mapedit" then
-					assert(false, "Map "..dirname.." has a corrupted barriers file. Re-save map to fix")
-				end
-
-				minetest.log("error", "Map "..dirname.." has a corrupted barriers file. Re-save map to fix")
+				minetest.log("error", "Map "..dirname.." is missing the barriers file. Re-save map to fix")
 			end
 		else
 			map.barrier_area = minetest.deserialize(meta:get("barrier_area"))


### PR DESCRIPTION
Fixes https://discord.com/channels/447819017391046687/448136831385468930/1148625553784578170
Prevents the game from crashing if some maps are missing the barrier files. Now it logs an error to specify which maps are missing the files.

![image](https://github.com/MT-CTF/capturetheflag/assets/88883098/631de220-7efd-4e15-b4ad-1206b383cfda)
