### PR TITLE
Make it possible to add a message to a donation

### DIFF
--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -97,14 +97,14 @@ end)
 
 minetest.register_chatcommand("donate", {
 	description = "Donate your match score to your teammate\nCan be used only once in 10 minutes",
-	params = "<playername> <score>",
+	params = "<playername> <score> <message>",
 	func = function(name, param)
 		local current_mode = ctf_modebase:get_current_mode()
 		if not current_mode or not ctf_modebase.match_started then
 			return false, "The match hasn't started yet!"
 		end
 
-		local pname, score = string.match(param, "^(.*) (.*)$")
+		local pname, score, dmessage = string.match(param, "^(%S*) (%S*) (.*)$")
 
 		if ctf_core.to_number(pname) then
 			pname, score = score, pname
@@ -159,7 +159,7 @@ minetest.register_chatcommand("donate", {
 		current_mode.recent_rankings.add(name, {score=-score}, true)
 
 		donate_timer[name] = os.time()
-		local donate_text = string.format("%s donated %s score to %s for their hard work", name, score, pname)
+		local donate_text = string.format("%s donated %s score to %s. '%s'", name, score, pname, dmessage)
 		minetest.chat_send_all(minetest.colorize("#00EEFF", donate_text))
 		ctf_modebase.announce(donate_text)
 

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -104,11 +104,13 @@ minetest.register_chatcommand("donate", {
 			return false, "The match hasn't started yet!"
 		end
 
-		local pname, score, dmessage = string.match(param, "^(%S*) (%S*) (.*)$")
+		local pname, score, dmessage = string.match(param, "^(%S*) (%S*)(.*)$")
 
 		if ctf_core.to_number(pname) then
 			pname, score = score, pname
 		end
+
+		dmessage = (dmessage and dmessage ~= "") and (":" .. dmessage) or ""
 
 		if not pname then
 			return false, "You should provide the player name!"
@@ -159,7 +161,7 @@ minetest.register_chatcommand("donate", {
 		current_mode.recent_rankings.add(name, {score=-score}, true)
 
 		donate_timer[name] = os.time()
-		local donate_text = string.format("%s donated %s score to %s. '%s'", name, score, pname, dmessage)
+		local donate_text = string.format("%s donated %s score to %s%s", name, score, pname, dmessage)
 		minetest.chat_send_all(minetest.colorize("#00EEFF", donate_text))
 		ctf_modebase.announce(donate_text)
 


### PR DESCRIPTION
Make it possible to add a message to a donation.
/donate player amount message

![image](https://github.com/MT-CTF/capturetheflag/assets/88883098/f5f0a461-b332-45b0-b1d7-a9fe33228490)
