### PR TITLE
Notify player when combat mode timer increases while inside blocks

### DIFF
--- a/mods/ctf/ctf_combat/ctf_combat_mode/init.lua
+++ b/mods/ctf/ctf_combat/ctf_combat_mode/init.lua
@@ -13,8 +13,12 @@ local function update(player)
 		return
 	end
 
-	local hud_message = "You are in combat [%ds left]"
-	hud_message = hud_message:format(combat.time)
+	if not suffocation_message then
+		local suffocation_message = ""
+	end
+
+	local hud_message = "You are in combat [%ds left] \n%s"
+	hud_message = hud_message:format(combat.time, suffocation_message)
 
 	if hud:exists(player, "combat_indicator") then
 		hud:change(player, "combat_indicator", {
@@ -36,8 +40,10 @@ local function update(player)
 
 	if node.groups.real_suffocation then -- From real_suffocation mod
 		combat.time = combat.time + 0.5
+		suffocation_message = "You are inside blocks. Move out to stop your combat timer from increasing."
 	else
 		combat.time = combat.time - 1
+		suffocation_message = ""
 	end
 
 	combat.timer = minetest.after(1, update, player)

--- a/mods/ctf/ctf_combat/ctf_combat_mode/init.lua
+++ b/mods/ctf/ctf_combat/ctf_combat_mode/init.lua
@@ -4,8 +4,6 @@ local healers = {}
 
 ctf_combat_mode = {}
 
-local suffocation_message = ""
-
 local function update(player)
 	local combat = hitters[player]
 
@@ -16,7 +14,7 @@ local function update(player)
 	end
 
 	local hud_message = "You are in combat [%ds left] \n%s"
-	hud_message = hud_message:format(combat.time, suffocation_message)
+	hud_message = hud_message:format(combat.time, combat.suffocation_message)
 
 	if hud:exists(player, "combat_indicator") then
 		hud:change(player, "combat_indicator", {
@@ -38,10 +36,10 @@ local function update(player)
 
 	if node.groups.real_suffocation then -- From real_suffocation mod
 		combat.time = combat.time + 0.5
-		suffocation_message = "You are inside blocks. Move out to stop your combat timer from increasing."
+		combat.suffocation_message = "You are inside blocks. Move out to stop your combat timer from increasing."
 	else
 		combat.time = combat.time - 1
-		suffocation_message = ""
+		combat.suffocation_message = ""
 	end
 
 	combat.timer = minetest.after(1, update, player)
@@ -60,6 +58,7 @@ function ctf_combat_mode.add_hitter(player, hitter, weapon_image, time)
 	combat.time = time
 	combat.last_hitter = hitter
 	combat.weapon_image = weapon_image
+	combat.suffocation_message = ""
 
 	if not combat.timer then
 		update(player)

--- a/mods/ctf/ctf_combat/ctf_combat_mode/init.lua
+++ b/mods/ctf/ctf_combat/ctf_combat_mode/init.lua
@@ -4,6 +4,8 @@ local healers = {}
 
 ctf_combat_mode = {}
 
+local suffocation_message = ""
+
 local function update(player)
 	local combat = hitters[player]
 
@@ -11,10 +13,6 @@ local function update(player)
 		hud:remove(player, "combat_indicator")
 		hitters[player] = nil
 		return
-	end
-
-	if not suffocation_message then
-		local suffocation_message = ""
 	end
 
 	local hud_message = "You are in combat [%ds left] \n%s"


### PR DESCRIPTION
When a player is in combat mode and is inside a block, the combat timer starts to increase. There is no explanation for why it is increasing, which can be confusing to new players. This PR notifies the player through the combat timer hud of a reason why the timer is increasing.