### PR TITLE
Change the position of the inbox HUD and more language supports

### DIFF
--- a/mods/other/email/hud.lua
+++ b/mods/other/email/hud.lua
@@ -11,7 +11,7 @@ function email.update_hud(player)
 			email.hud:add(player, "email:icon", {
 				hud_elem_type = "image",
 				name = "MailIcon",
-				position = {x=0.52, y=0.52},
+				position = {x=0.06, y=0.96},
 				text="email_mail.png",
 				scale = {x=1,y=1},
 				alignment = {x=0.5, y=0.5},
@@ -20,7 +20,7 @@ function email.update_hud(player)
 			email.hud:add(player, "email:text", {
 				hud_elem_type = "text",
 				name = "MailText",
-				position = {x=0.55, y=0.52},
+				position = {x=0.08, y=0.96},
 				text= #inbox .. " /inbox",
 				scale = {x=1,y=1},
 				alignment = {x=0.5, y=0.5},

--- a/mods/other/email/init.lua
+++ b/mods/other/email/init.lua
@@ -204,7 +204,9 @@ function email.send_mail(aname, ato, msg)
 
 	email.save()
 
-	minetest.chat_send_player(to, "Mail from " .. name .. ": " .. msg)
+	minetest.chat_send_player(to, minetest.colorize("#00FF00", "Mail from " .. minetest.colorize("#92C5FC", name) .. ": " .. msg))
+
+
 
 	return true, S("Message sent to @1", ato)
 end

--- a/mods/other/email/locale/email.es.tr
+++ b/mods/other/email/locale/email.es.tr
@@ -1,0 +1,23 @@
+# textdomain: email
+(@1) You have mail! Type /inbox to recieve=(@1) ¡Tienes correo! Escribe /inbox para recibirlo
+Your Inbox=Tu Bandeja de Entrada
+Date=Fecha
+From=De
+Message=Mensaje
+Well done! Your inbox is empty!=¡Bien hecho! ¡Tu bandeja de entrada está vacía!
+Delete All=Eliminar Todo
+Close=Cerrar
+Exit then type /mail username message to reply=Sal y luego escribe /mail nombre de usuario y el mensaje para responder
+Your inbox is empty!=¡Tu bandeja de entrada está vacía!
+@1 items in your inbox:=@1 elementos en tu bandeja de entrada:
+End of mail (@1 items)=Fin del correo (@1 elementos)
+Opened inbox!=¡Bandeja de entrada abierta!
+Inbox=Bandeja de Entrada
+Inbox cleared!=¡Bandeja de entrada vaciada!
+Player '@1' does not exist=El jugador '@1' no existe
+Message sent to @1=Mensaje enviado a @1
+Inbox: Blank to see inbox. Use 'clear' to empty inbox, 'text' for text only.=Bandeja de entrada: Deja en blanco para ver la bandeja de entrada. Usa 'clear' para vaciar la bandeja, 'text' para solo texto.
+Inbox cleared=Bandeja de entrada vaciada
+<playername> <some message>=<nombredejugador> <algún mensaje>
+mail: add a message to a player's inbox=mail: agregar un mensaje a la bandeja de entrada de un jugador
+Usage: mail <playername> <some message>=Uso: mail <nombredejugador> <algún mensaje>

--- a/mods/other/email/locale/email.pt_BR.tr
+++ b/mods/other/email/locale/email.pt_BR.tr
@@ -1,0 +1,23 @@
+# textdomain: email
+(@1) You have mail! Type /inbox to recieve=(@1) Você tem correio! Digite /inbox para receber
+Your Inbox=Sua Caixa de Entrada
+Date=Data
+From=De
+Message=Mensagem
+Well done! Your inbox is empty!=Bem feito! Sua caixa de entrada está vazia!
+Delete All=Excluir Tudo
+Close=Fechar
+Exit then type /mail username message to reply=Sair e depois digite /mail nomeusuário mensagem para responder
+Your inbox is empty!=Sua caixa de entrada está vazia!
+@1 items in your inbox:=@1 itens na sua caixa de entrada:
+End of mail (@1 items)=Fim do correio (@1 itens)
+Opened inbox!=Caixa de entrada aberta!
+Inbox=Caixa de Entrada
+Inbox cleared!=Caixa de entrada limpa!
+Player '@1' does not exist=Jogador '@1' não existe
+Message sent to @1=Mensagem enviada para @1
+Inbox: Blank to see inbox. Use 'clear' to empty inbox, 'text' for text only.=Caixa de entrada: Deixe em branco para ver a caixa de entrada. Use 'clear' para esvaziar a caixa, 'text' para texto apenas.
+Inbox cleared=Caixa de entrada limpa
+<playername> <some message>=<nomejogador> <algumamensagem>
+mail: add a message to a player's inbox=mail: adicionar uma mensagem à caixa de entrada de um jogador
+Usage: mail <playername> <some message>=Uso: mail <nomejogador> <algumamensagem>

--- a/mods/other/email/locale/email.ru.tr
+++ b/mods/other/email/locale/email.ru.tr
@@ -1,0 +1,23 @@
+# textdomain: email
+(@1) You have mail! Type /inbox to recieve=(@1) У вас новое письмо! Введите /inbox для получения
+Your Inbox=Ваш почтовый ящик
+Date=Дата
+From=От
+Message=Сообщение
+Well done! Your inbox is empty!=Отлично! Ваша почта пуста!
+Delete All=Удалить все
+Close=Закрыть
+Exit then type /mail username message to reply=Выйдите, затем введите /mail имяпользователя сообщение для ответа
+Your inbox is empty!=Ваш почтовый ящик пуст!
+@1 items in your inbox:=@1 элементов в вашем почтовом ящике:
+End of mail (@1 items)=Конец почты (@1 элементов)
+Opened inbox!=Почтовый ящик открыт!
+Inbox=Почтовый ящик
+Inbox cleared!=Почтовый ящик очищен!
+Player '@1' does not exist=Игрок '@1' не существует
+Message sent to @1=Сообщение отправлено @1
+Inbox: Blank to see inbox. Use 'clear' to empty inbox, 'text' for text only.=Почтовый ящик: Пусто для просмотра почты. Используйте 'clear', чтобы очистить почтовый ящик, 'text' только для текста.
+Inbox cleared=Почтовый ящик очищен
+<playername> <some message>=<имяигрока> <какоесообщение>
+mail: add a message to a player's inbox=mail: добавить сообщение в почтовый ящик игрока
+Usage: mail <playername> <some message>=Использование: mail <имяигрока> <какоесообщение>


### PR DESCRIPTION
## Changes Made

1. **HUD Position Changed to Bottom Left Corner:**
   - The position of the mail HUD has been changed to the bottom left corner instead of the center. This was done due as the previous center position could be distracting during gameplay. The HUD will now be in a less intrusive location.

![screenshot_20231126_124416](https://github.com/MT-CTF/capturetheflag/assets/73263831/66da500d-c910-4004-a492-a709f366d3db)

2. **Mail Message Made More Perceptible:**
   - The perception of the mail message uses `minetest.colorize` now, the "Mail from **playername**" message is highlighted in a specific color, making it easier to read in the chat and providing a clear indication to the player that they have received mail.
   
   
![screenshot_20231126_124343](https://github.com/MT-CTF/capturetheflag/assets/73263831/1e1d3e58-8c8c-46d0-ad9c-f2c3cc1000a3)


3. **Additional Support for Other Languages:**
   - Added support for additional languages, specifically, Spanish, Brazilian Portuguese and Russian for email mod
