### PR TITLE
Allow grenade explosions to break ice on water

### DIFF
--- a/mods/pvp/grenades/grenades.lua
+++ b/mods/pvp/grenades/grenades.lua
@@ -1,11 +1,13 @@
+local grenade_remove_list = {
+	"group:flora", "group:mushroom", -- Flowers
+	"default:snow", "winterize:ice", -- Winter-specific
+}
 
 local function remove_flora(pos, radius)
 	local pos1 = vector.subtract(pos, radius)
 	local pos2 = vector.add(pos, radius)
 
-	for _, p in ipairs(minetest.find_nodes_in_area(pos1, pos2, {
-		"group:flora", "group:mushroom", "default:snow"
-	})) do
+	for _, p in ipairs(minetest.find_nodes_in_area(pos1, pos2, grenade_remove_list)) do
 		if vector.distance(pos, p) <= radius then
 			minetest.remove_node(p)
 		end


### PR DESCRIPTION
Currently, grenade explosions break snow layers. Thus, it should make sense to break the more fragile ice layers.

This PR is ready for review.