### PR TITLE
babel, utf8_simple: Add in-game translator mod from JMA and a small library for handling UTF-8 text.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -12,7 +12,7 @@ globals = {
 	"dropondie", "grenades",
 
 	"chatcmdbuilder", "crafting", "hpbar", "playertag", "random_messages",
-	"skybox", "throwable_snow", "worldedit", "filter",
+	"skybox", "throwable_snow", "worldedit", "filter", "utf8_simple", "babel",
 
 	"default", "doors", "player_api", "sfinv", "binoculars",
 

--- a/mods/other/babel/LICENSE
+++ b/mods/other/babel/LICENSE
@@ -1,0 +1,166 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.
+

--- a/mods/other/babel/google_engine.lua
+++ b/mods/other/babel/google_engine.lua
@@ -1,0 +1,134 @@
+local httpapi
+
+function babel.register_http(hat)
+	httpapi = hat
+end
+
+babel.engine = "TRANSLATOR" -- used for tagging messages
+
+babel.langcodes = {
+	af = "Afrikaans",
+	sq = "Albanian",
+	am = "Amharic",
+	ar = "Arabic",
+	hy = "Armenian",
+	az = "Azerbaijan",
+	ba = "Bashkir",
+	eu = "Basque",
+	be = "Belarusian",
+	bn = "Bengali",
+	bs = "Bosnian",
+	bg = "Bulgarian",
+	ca = "Catalan",
+	ceb = "Cebuano",
+	zh = "Chinese",
+	hr = "Croatian",
+	cs = "Czech",
+	da = "Danish",
+	nl = "Dutch",
+	en = "English",
+	eo = "Esperanto",
+	et = "Estonian",
+	fi = "Finnish",
+	fr = "French",
+	gl = "Galician",
+	ka = "Georgian",
+	de = "German",
+	el = "Greek",
+	gu = "Gujarati",
+	ht = "Haitian",
+	he = "Hebrew",
+	mrj = "Hill",
+	hi = "Hindi",
+	hu = "Hungarian",
+	is = "Icelandic",
+	id = "Indonesian",
+	ga = "Irish",
+	it = "Italian",
+	ja = "Japanese",
+	jv = "Javanese",
+	kn = "Kannada",
+	kk = "Kazakh",
+	ko = "Korean",
+	ky = "Kyrgyz",
+	la = "Latin",
+	lv = "Latvian",
+	lt = "Lithuanian",
+	mk = "Macedonian",
+	mg = "Malagasy",
+	ms = "Malay",
+	ml = "Malayalam",
+	mt = "Maltese",
+	mi = "Maori",
+	mr = "Marathi",
+	mhr = "Mari",
+	mn = "Mongolian",
+	ne = "Nepali",
+	no = "Norwegian",
+	pap = "Papiamento",
+	fa = "Persian",
+	pl = "Polish",
+	pt = "Portuguese",
+	pa = "Punjabi",
+	ro = "Romanian",
+	ru = "Russian",
+	gd = "Scottish",
+	sr = "Serbian",
+	si = "Sinhala",
+	sk = "Slovakian",
+	sl = "Slovenian",
+	es = "Spanish",
+	su = "Sundanese",
+	sw = "Swahili",
+	sv = "Swedish",
+	tl = "Tagalog",
+	tg = "Tajik",
+	ta = "Tamil",
+	tt = "Tatar",
+	te = "Telugu",
+	th = "Thai",
+	tr = "Turkish",
+	udm = "Udmurt",
+	uk = "Ukrainian",
+	ur = "Urdu",
+	uz = "Uzbek",
+	vi = "Vietnamese",
+	cy = "Welsh",
+	xh = "Xhosa",
+	yi = "Yiddish",
+}
+
+local function urlencode(url)
+	if url == nil then
+		return
+	end
+	url = url:gsub("\n", "\r\n")
+	url = url:gsub(".", function(c)
+		return string.format("%%%02X", string.byte(c))
+	end)
+	return url
+end
+
+function babel.translateGoogle(self, phrase, lang, handler)
+	local apiurl = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl="
+	local transurl = apiurl .. babel.sanitize(lang) .. "&dt=t&q=" .. urlencode(phrase)
+
+	httpapi.fetch({url = transurl}, function(htresponse)
+		if htresponse.succeeded then
+			local response_data = minetest.parse_json(htresponse.data)
+			if response_data and response_data[1] then
+				local sentences = ""
+				for k = 1, #response_data[1] do
+					sentences = sentences .. response_data[1][k][1] -- Merge the sentences in one line
+				end
+				handler(sentences)
+			else
+				handler("Failed request")
+				minetest.log("error", "Error on requesting, received invalid data: " .. dump(htresponse))
+			end
+		else
+			handler("Failed request")
+			minetest.log("error", "Error on requesting: " .. dump(htresponse))
+		end
+	end)
+end

--- a/mods/other/babel/init.lua
+++ b/mods/other/babel/init.lua
@@ -1,0 +1,247 @@
+-- SPDX-License-Identifier: LGPL-3.0-only
+-- Copyright (c) 2023 Marko Petrović, Nanowolf4
+babel = {}
+local storage = minetest.get_mod_storage()
+
+local function getplayerlanguage(player)
+	local lang = storage:get_string("lang:"..player)
+	if not lang or lang == "" then
+		return "en"
+	end
+	return lang
+end
+-- Preferred language was previously stored in player metadata. Switch to mod storage.
+local function getplayerlanguage_playermeta(player)
+	return minetest.get_player_by_name(player) and (minetest.get_player_by_name(player):get_meta():get("lang") or "en")
+end
+minetest.register_on_joinplayer(function(player)
+	local name = player:get_player_name()
+	local language = getplayerlanguage_playermeta(name)
+	if language ~= "en" then
+		storage:set_string("lang:"..name, language)
+		-- Delete the key from player meta
+		player:get_meta():set_string("lang", "")
+	end
+end)
+
+minetest.register_privilege("babelmoderator")
+
+dofile(minetest.get_modpath("babel").."/google_engine.lua")
+
+local httpapitable = minetest.request_http_api() or error("babel: http api required!")
+
+babel.register_http(httpapitable)
+
+babel.sanitize = function(stringdata)
+	stringdata = stringdata:gsub("&", "%%26")
+	stringdata = stringdata:gsub("#","%%23")
+
+	return stringdata
+end
+
+function babel.validate_lang(self, langstring)
+	for target, _ in pairs(babel.langcodes) do
+		if target == langstring then
+			return true
+		end
+	end
+	return false
+end
+
+local chat_history = {}
+
+local function components(mystring)
+	local iter = mystring:gmatch("%S+")
+	local first = iter()
+	if not first then
+		return nil
+	end
+	if not iter() then
+		return first, nil
+	end
+
+	local second = mystring:gsub("^"..first.." ", "", 1)
+	return first, second
+end
+
+
+local function dotranslate(lang, phrase, handler)
+	return babel:translateGoogle(minetest.strip_colors(phrase), lang, handler)
+end
+
+local charTable = {
+    ["а"] = "a", ["б"] = "b", ["в"] = "v", ["г"] = "g", ["д"] = "d", ["е"] = "e", ["з"] = "z",
+    ["и"] = "i", ["ј"] = "j", ["к"] = "k", ["л"] = "l", ["м"] = "m", ["н"] = "n", ["о"] = "o",
+    ["п"] = "p", ["р"] = "r", ["с"] = "s", ["т"] = "t", ["у"] = "u", ["ф"] = "f", ["х"] = "h", ["ц"] = "c"
+}
+
+local function cyrillicToLatin(input)
+	return utf8_simple.replace(input, charTable)
+end
+
+minetest.register_on_chat_message(function(player, message)
+	if minetest.player_exists(player) and not minetest.check_player_privs(player, {shout = true}) then
+		return
+	end
+
+	local targetlang
+
+	-- Search for %* token at the end
+	for token in message:gmatch("[^%%]+") do
+		targetlang = utf8_simple.sub(token, 1, 2)
+		-- No percent sign in the message -> token = message
+		if token == message then
+			targetlang = nil
+		end
+	end
+
+	if not targetlang then
+		return false
+	end
+
+	-- Remove targetlang token from the end of the message
+	message = utf8_simple.reverse(message)
+	local reversedLangCode = utf8_simple.reverse(targetlang)
+	-- Escaping special characters in targetlang before using it in pattern matching
+	reversedLangCode = reversedLangCode:gsub("[%p%c]", "%%%1")
+
+	message = message:gsub(reversedLangCode.."%%",'',1)
+	message = utf8_simple.reverse(message)
+	targetlang = cyrillicToLatin(targetlang)
+
+	-- True, or error string
+	local validation = babel:validate_lang(targetlang)
+
+	if validation ~= true then
+		minetest.chat_send_player(player, "Bad language code!")
+	else
+		dotranslate(targetlang, message, function(newphrase)
+			minetest.chat_send_all("[Translated "..player.."]: "..newphrase)
+		end)
+	end
+end)
+
+minetest.register_chatcommand("b", {
+	description = "Translate a player's last chat message. Use /lang to set your language",
+	params = "<playername>",
+	func = function (player, argstring)
+		argstring = argstring or ""
+		local args = argstring:split(" ")
+
+		local targetplayer = args[1]
+
+		if not targetplayer then
+			minetest.chat_send_player(player, "Missing player name!")
+			return
+		end
+
+		local targetlang = args[2]
+
+		if not targetlang then
+			targetlang = getplayerlanguage(player)
+		end
+		targetlang = cyrillicToLatin(targetlang)
+
+		local validation = babel:validate_lang(targetlang)
+		if validation ~= true then
+			minetest.chat_send_player(player, "Bad language: " .. (targetlang or "(Not set!)"))
+			return
+		end
+
+		if not chat_history[targetplayer] then
+			minetest.chat_send_player(player, targetplayer.." has not said anything")
+			return
+		end
+
+		dotranslate(targetlang, chat_history[targetplayer], function(newphrase)
+			minetest.chat_send_player(player, "[Translated]: "..newphrase)
+		end)
+	end
+})
+
+minetest.register_chatcommand("bmsg", {
+	description = "Send a private message to a player, in their preferred language",
+	params = "<player> <sentence>",
+	privs = {shout = true},
+	func = function(player, argstring)
+		local targetplayer, targetphrase = components(argstring)
+		if not targetplayer then
+			minetest.chat_send_player(player, "You have to provide player name!")
+			return
+		end
+		if not targetphrase then
+			minetest.chat_send_player(player, "Write the message you wish to send!")
+			return
+		end
+
+		local targetlang = getplayerlanguage(targetplayer)
+		targetlang = cyrillicToLatin(targetlang)
+
+		if not babel:validate_lang(targetlang) then
+			minetest.chat_send_player(player, "Bad target language")
+			return
+		end
+
+		if not minetest.get_player_by_name(targetplayer) then
+			minetest.chat_send_player(player, targetplayer.." is not a connected player")
+			return
+		end
+
+		dotranslate(targetlang, targetphrase, function(newphrase)
+			minetest.chat_send_player(targetplayer, "PM from " .. player .. ": " .. targetphrase .. "\n" ..
+			"[Translated PM from " .. player .. "]: " .. newphrase)
+			minetest.chat_send_player(player, "PM to " .. targetplayer .. ": " .. targetphrase .. "\n" ..
+			"[Translated PM to " .. targetplayer .. "]: " .. newphrase)
+			minetest.log("action", player .. " PM to " .. targetplayer .. " [Translated]: " .. newphrase)
+		end)
+	end
+})
+
+minetest.register_chatcommand("bbcodes", {
+	description = "List the available language codes",
+	func = function(player,command)
+		minetest.chat_send_player(player,dump(babel.langcodes))
+	end
+})
+
+minetest.register_chatcommand("bbset", {
+	description = "Set a player's preferred language",
+	params = "<player> <langcode>",
+	privs = {babelmoderator = true},
+	func = function(player, message)
+		local tplayer, langcode = components(message)
+		if not tplayer then
+			minetest.chat_send_player(player, "You have to provide player name!")
+			return
+		elseif not langcode then
+			minetest.chat_send_player(player, "You have to provide language code!")
+		end
+
+		if not minetest.player_exists(tplayer) then
+			minetest.chat_send_player(player, "Player doesn't exist!")
+			return
+		end
+
+		if babel:validate_lang(cyrillicToLatin(langcode)) then
+			storage:set_string("lang:"..tplayer, langcode)
+			minetest.chat_send_player(player, tplayer .. " : " .. langcode )
+		else
+			minetest.chat_send_player(player, tplayer .. " : Invalid language code!" )
+		end
+	end,
+})
+
+minetest.register_chatcommand("lang", {
+	description = "Set preferred language",
+	params = "<langcode>",
+	privs = {},
+	func = function(name, param)
+		param = param or ""
+		if babel:validate_lang(cyrillicToLatin(param)) then
+			storage:set_string("lang:"..name, param)
+			minetest.chat_send_player(name, "Your preferred language is set to (" .. param .. ")" )
+		else
+			minetest.chat_send_player(name,"Incorrect usage or the lang code is wrong. Example: (/lang en)" )
+		end
+	end,
+})

--- a/mods/other/babel/mod.conf
+++ b/mods/other/babel/mod.conf
@@ -1,0 +1,3 @@
+name = babel
+depends = utf8_simple
+description = Add translation commands to Minetest

--- a/mods/other/utf8_simple/LICENSE
+++ b/mods/other/utf8_simple/LICENSE
@@ -1,0 +1,22 @@
+This code is based on the external MIT-licensed library.
+Original copyright notice follows:
+
+Copyright © 2015 blitmap <coroutines@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/mods/other/utf8_simple/README.md
+++ b/mods/other/utf8_simple/README.md
@@ -1,0 +1,152 @@
+# lua-utf8-simple
+
+This "library" is meant to be a very thin helper that you can easily drop in to another project without really calling it a dependency.  It aims to provide the most minimal of handling functions for working with utf8 strings.  It does not aim to be feature-complete or even error-descriptive.  It works for what is practical but not complex.  You have been warned. =^__^=
+
+## The require() Line
+
+```lua
+local utf8 = require('utf8_simple')
+```
+
+## The Only Functions You Need to Know
+
+### utf8.chars(s[, no_subs])
+- s: (string) the utf8 string to iterate over (by characters)
+- nosubs: (boolean) true turns the substring utf8 characters into byte-lengths
+
+```lua
+-- i is the character/letter index within the string
+-- c is the utf8 character (string of 1 or more bytes)
+-- b is the byte index within the string
+for i, c, b in utf8.chars('Αγαπώ τηγανίτες') do
+	print(i, c, b)
+end
+```
+
+Output:
+
+	1	Α	1
+	2	γ	3
+	3	α	5
+	4	π	7
+	5	ώ	9
+	6		11
+	7	τ	12
+	8	η	14
+	9	γ	16
+	10	α	18
+	11	ν	20
+	12	ί	22
+	13	τ	24
+	14	ε	26
+	15	ς	28
+
+### ALTERNATE FORM
+Creating small substrings can be a performance concern, the 2nd parameter to utf8.chars()
+allows you to toggle the substrings to instead by the byte width of the character.
+
+This is for situations when you only care about the byte width (less common).
+
+```lua
+-- i is the character/letter index within the string
+-- w is the utf8 character width (in bytes)
+-- b is the byte index within the string
+for i, w, b in utf8.chars('Αγαπώ τηγανίτες', true) do
+	print(i, w, b)
+end
+```
+
+Output:
+
+	1	2	1
+	2	2	3
+	3	2	5
+	4	2	7
+	5	2	9
+	6	1	11
+	7	2	12
+	8	2	14
+	9	2	16
+	10	2	18
+	11	2	20
+	12	2	22
+	13	2	24
+	14	2	26
+	15	2	28
+
+### utf8.map(s, f[, no_subs])
+- s: (string) the utf8 string to map 'f' over
+- f: (function) a function accepting: f(visual_index, utf8_char -or- width, byte_index)
+- no_subs: (boolean) true means don't make small substrings from each character (byte width instead)
+
+returns: (nothing)
+
+```lua
+> utf8.map('Αγαπώ τηγανίτες', print) -- does the same as the first example above
+```
+
+```lua
+> utf8.map('Αγαπώ τηγανίτες', print, true) -- the alternate form from above
+```
+
+## Others
+
+### utf8.len(s)
+- s: (string) the utf8 string
+
+returns: (number) the number of utf8 characters in s (not the byte length)
+
+note: be aware of "invisible" utf8 characters
+
+```lua
+> = utf8.len('Αγαπώ τηγανίτες')
+15
+```
+
+### utf8.reverse(s)
+- s: (string) the utf8 string
+
+returns: (string) the utf8-reversed form of s
+
+note: reversing left-to-right utf8 strings that include directional formatting characters will look odd
+
+```lua
+> = utf8.reverse('Αγαπώ τηγανίτες')
+ςετίναγητ ώπαγΑ
+```
+
+### utf8.strip(s)
+- s: (string) the utf8 string
+
+returns: (string) s with all non-ascii characters removed (characters > 1 byte)
+
+```lua
+> = utf8.strip('cat♥dog')
+catdog
+```
+
+### utf8.replace(s, map)
+- s: (string) the utf8 string
+- map: (table) keys are utf8 characters to replace, values are their replacement
+
+returns: (string) s with all the key-characters in map replaced
+
+note: the keys must be utf8 characters, the values **can** be strings
+
+```lua
+> = utf8.replace('∃y ∀x ¬(x ≺ y)', { ['∃'] = 'E', ['∀'] = 'A', ['¬'] = '\r\n', ['≺'] = '<' })
+Ey Ax 
+(x < y)
+```
+
+### utf8.sub(s, i, j)
+- s: (string) the utf8 string
+- i: (string) the starting index in the utf8 string
+- j: (stirng) the ending index in the utf8 string
+
+returns: (string) the substring formed from i to j, inclusive (this is a utf8-aware string.sub())
+
+```lua
+> = utf8.sub('Αγαπώ τηγανίτες', 3, -5)
+απώ τηγαν
+```

--- a/mods/other/utf8_simple/init.lua
+++ b/mods/other/utf8_simple/init.lua
@@ -1,0 +1,124 @@
+-- SPDX-License-Identifier: MIT
+-- ABNF from RFC 3629
+--
+-- UTF8-octets = *( UTF8-char )
+-- UTF8-char = UTF8-1 / UTF8-2 / UTF8-3 / UTF8-4
+-- UTF8-1 = %x00-7F
+-- UTF8-2 = %xC2-DF UTF8-tail
+-- UTF8-3 = %xE0 %xA0-BF UTF8-tail / %xE1-EC 2( UTF8-tail ) /
+-- %xED %x80-9F UTF8-tail / %xEE-EF 2( UTF8-tail )
+-- UTF8-4 = %xF0 %x90-BF 2( UTF8-tail ) / %xF1-F3 3( UTF8-tail ) /
+-- %xF4 %x80-8F 2( UTF8-tail )
+-- UTF8-tail = %x80-BF
+
+-- 0xxxxxxx                            | 007F   (127)
+-- 110xxxxx	10xxxxxx                   | 07FF   (2047)
+-- 1110xxxx	10xxxxxx 10xxxxxx          | FFFF   (65535)
+-- 11110xxx	10xxxxxx 10xxxxxx 10xxxxxx | 10FFFF (1114111)
+
+local pattern = '[%z\1-\127\194-\244][\128-\191]*'
+utf8_simple = {}
+
+-- helper function
+local posrelat =
+	function (pos, len)
+		if pos < 0 then
+			pos = len + pos + 1
+		end
+
+		return pos
+	end
+
+-- THE MEAT
+
+-- maps f over s's utf8 characters f can accept args: (visual_index, utf8_character, byte_index)
+utf8_simple.map =
+	function (s, f, no_subs)
+		local i = 0
+
+		if no_subs then
+			for b, e in s:gmatch('()' .. pattern .. '()') do
+				i = i + 1
+				local c = e - b
+				f(i, c, b)
+			end
+		else
+			for b, c in s:gmatch('()(' .. pattern .. ')') do
+				i = i + 1
+				f(i, c, b)
+			end
+		end
+	end
+
+-- THE REST
+
+-- generator for the above -- to iterate over all utf8 chars
+utf8_simple.chars =
+	function (s, no_subs)
+		return coroutine.wrap(function () return utf8_simple.map(s, coroutine.yield, no_subs) end)
+	end
+
+-- returns the number of characters in a UTF-8 string
+utf8_simple.len =
+	function (s)
+		-- count the number of non-continuing bytes
+		return select(2, s:gsub('[^\128-\193]', ''))
+	end
+
+-- replace all utf8 chars with mapping
+utf8_simple.replace =
+	function (s, map)
+		return s:gsub(pattern, map)
+	end
+
+-- reverse a utf8 string
+utf8_simple.reverse =
+	function (s)
+		-- reverse the individual greater-than-single-byte characters
+		s = s:gsub(pattern, function (c) return #c > 1 and c:reverse() end)
+
+		return s:reverse()
+	end
+
+-- strip non-ascii characters from a utf8 string
+utf8_simple.strip =
+	function (s)
+		return s:gsub(pattern, function (c) return #c > 1 and '' end)
+	end
+
+-- like string.sub() but i, j are utf8 strings
+-- a utf8-safe string.sub()
+utf8_simple.sub =
+	function (s, i, j)
+		local l = utf8_simple.len(s)
+
+		i =       posrelat(i, l)
+		j = j and posrelat(j, l) or l
+
+		if i < 1 then i = 1 end
+		if j > l then j = l end
+
+		if i > j then return '' end
+
+		local diff = j - i
+		local iter = utf8_simple.chars(s, true)
+
+		-- advance up to i
+		for _ = 1, i - 1 do iter() end
+
+		local c, b = select(2, iter())
+
+		-- i and j are the same, single-charaacter sub
+		if diff == 0 then
+			return string.sub(s, b, b + c - 1)
+		end
+
+		i = b
+
+		-- advance up to j
+		for _ = 1, diff - 1 do iter() end
+
+		c, b = select(2, iter())
+
+		return string.sub(s, i, b + c - 1)
+	end

--- a/mods/other/utf8_simple/mod.conf
+++ b/mods/other/utf8_simple/mod.conf
@@ -1,0 +1,2 @@
+name = utf8_simple
+description = Adds simple functions for working with UTF-8 text


### PR DESCRIPTION
Hello,
As promised, here is the pull request for adding the in-game translator mod from JMA, along with it's dependency -> utf8_simple mod that provides a small library for dealing with UTF-8, non-ASCII characters.

utf8_simple is a separate mod because it can potentially be used in many other mods, i.e. it's API is generic and not bound to the translator in any meaningful way. Minetest also does not include built-in UTF-8 Lua API, and as far as I know, there has not been much attention on that [issue](https://github.com/minetest/minetest/issues/10939), necessitating the use of a mod to provide such functionality.

The provided version of the translator mod is a stripped down version from JMA, as to require minimal dependencies. The version on JMA also includes dependencies on filter_caps (to prevent translations with all capital letters emerging), filter (to filter swear words in translation output as well) and discordmt for integration with the Discord bot, making the translator usable on Discord ingame-chat channel as well. If any of these additional functionalities were ever required here, they could be added with another commit.

The translator uses Google Translate API (not to be confused with the Google Cloud Translation API) for it's translation engine.

Thank you for your attention.
Best regards,
Marko Petrović