### PR TITLE
Fix bug - Disappearing items in team chest

### DIFF
--- a/mods/ctf/ctf_teams/team_chest.lua
+++ b/mods/ctf/ctf_teams/team_chest.lua
@@ -318,7 +318,9 @@ for _, team in ipairs(ctf_teams.teamlist) do
 		end
 		meta:set_string("dropped_by", "")
 		local inv = minetest.get_inventory({ type="node", pos=pos })
-		inv:set_stack(listname, index, stack)
+		local stack_ = inv:get_stack(listname,index)
+		stack_:get_meta():set_string("dropped_by", "")
+		inv:set_stack(listname, index, stack_)
 	end
 
 		function def.on_metadata_inventory_take(pos, listname, index, stack, player)


### PR DESCRIPTION

- [ * ] This PR has been tested locally
Fix issue #1298, which is caused because the function `on_metadata_inventory_put` is called after the items are placed, however the `stack` is not updated, and is hence the items in the position gets `reset` to stack. Thereby not merging with existing items already present in that position. 