### PR TITLE
Change donate command to accept multiple recipients

### DIFF
--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -182,12 +182,13 @@ minetest.register_chatcommand("donate", {
 
 			if receivers[pname] then
 				return false, "You cannot donate more than once to the same person."
-			end
-
-			if not receivers[pname] then
+			else
 				receivers[pname] = true
 			end
+		end
 
+		local pname, names, count = next(receivers), "", 0
+		while pname do
 			current_mode.recent_rankings.add(pname, {score=score}, true)
 			current_mode.recent_rankings.add(name, {score=-score}, true)
 
@@ -195,22 +196,17 @@ minetest.register_chatcommand("donate", {
 				"Player '%s' donated %s score to player '%s'", name, score, pname
 			))
 
-			minetest.chat_send_all(pname)
-		end
-
-		local r, names, count = next(receivers), "", 0
-		while r do
-			names = names .. r
+			names = names .. pname
 			count = count + 1
 
-			n = next(receivers, r)
+			n = next(receivers, pname)
 
 			if n then
 				names = names .. ", "
 			end
-			r = n
+			pname = n
 		end
-		separators = {string.find(names, ", (%S+)$")}
+
 		if count > 2 then
 			names = string.gsub(names, ", (%S+)$", ", and %1")
 		elseif count > 1 then

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -192,11 +192,10 @@ minetest.register_chatcommand("donate", {
 
 			names = names .. pname
 
-			n = next(pnames, pname)
-			if n then
+			pname = next(pnames, pname)
+			if pname then
 				names = names .. ", "
 			end
-			pname = n
 		end
 
 		if pcount > 2 then

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -165,8 +165,8 @@ minetest.register_chatcommand("donate", {
 			(current_mode.rankings:get(name) or {}).score or 0
 		)
 		if scoretotal > cur_score / 2 then
-		end
 			return false, "You can donate only half of your match score!"
+		end
 
 		if donate_timer[name] and donate_timer[name] + 150 > os.time() then
 			local time_diff = donate_timer[name] + 150 - os.time()

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -155,10 +155,6 @@ minetest.register_chatcommand("donate", {
 			return false, "You should donate at least 5 score!"
 		end
 
-		if score > 400 then
-			return false, "You can donate no more than 400 score!"
-		end
-
 		local scoretotal = score * pcount
 		local cur_score = math.min(
 			current_mode.recent_rankings.get(name).score or 0,

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -97,7 +97,7 @@ end)
 
 minetest.register_chatcommand("donate", {
 	description = "Donate your match score to your teammate\nCan be used only once in 2.5 minutes",
-	params = "<playername> <score> [message]",
+	params = "<playername> [playernames] <score> [message]",
 	func = function(name, param)
 		local current_mode = ctf_modebase:get_current_mode()
 		if not current_mode or not ctf_modebase.match_started then

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -165,8 +165,8 @@ minetest.register_chatcommand("donate", {
 			(current_mode.rankings:get(name) or {}).score or 0
 		)
 		if scoretotal > cur_score / 2 then
-			return false, "You can donate only half of your match score!"
 		end
+			return false, "You can donate only half of your match score!"
 
 		if donate_timer[name] and donate_timer[name] + 150 > os.time() then
 			local time_diff = donate_timer[name] + 150 - os.time()
@@ -178,10 +178,11 @@ minetest.register_chatcommand("donate", {
 
 		dmessage = (dmessage and dmessage ~= "") and (":" .. dmessage) or ""
 
+
+		current_mode.recent_rankings.add(name, {score=-scoretotal}, true)
 		local names = ""
 		for pname, team in pairs(pnames) do
 			current_mode.recent_rankings.add(pname, {score=score}, true)
-			current_mode.recent_rankings.add(name, {score=-score}, true)
 			minetest.log("action", string.format(
 				"Player '%s' donated %s score to player '%s'", name, score, pname
 			))

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -110,17 +110,17 @@ minetest.register_chatcommand("donate", {
 
 		for p in string.gmatch(param, "%S+") do
 			if #dmessage > 0 then
-				dmessage = dmessage .. " "
+				dmessage = dmessage .. " " .. p
 			elseif ctf_core.to_number(p) and score == 0 then
 				score = p
-				break
-			end
-			local team = ctf_teams.get(p)
-			if not team and receiver then
-				dmessage = dmessage .. p
 			else
-				pnames[p] = team
-				receiver = true
+				local team = ctf_teams.get(p)
+				if not team and receiver then
+					dmessage = dmessage .. p
+				else
+					pnames[p] = team
+					receiver = true
+				end
 			end
 		end
 
@@ -180,6 +180,10 @@ minetest.register_chatcommand("donate", {
 				return false, string.format("Player %s is not on your team!", pname)
 			end
 
+			if receivers[pname] then
+				return false, "You cannot donate more than once to the same person."
+			end
+
 			if not receivers[pname] then
 				receivers[pname] = true
 			end
@@ -190,6 +194,8 @@ minetest.register_chatcommand("donate", {
 			minetest.log("action", string.format(
 				"Player '%s' donated %s score to player '%s'", name, score, pname
 			))
+
+			minetest.chat_send_all(pname)
 		end
 
 		local r, names, count = next(receivers), "", 0


### PR DESCRIPTION
I have tested this about as well as I can think. I do not have the ability to test with more than 2 clients. It might not be written as cleanly as possible, although I've tried.

I've tried to keep flexibility with the order of parameters. Player names are checked for validity until there is at least one valid player name and a score amount, after which all remaining text is assumed to be the donation message.

[suggestion here](https://discord.com/channels/447819017391046687/448136308108296213/1249032532847099944)
- [x] This PR has been tested locally
