### PR TITLE
Show message to healer on healing a player, and the player who died that the killer got x points

### DIFF
--- a/mods/ctf/ctf_combat/ctf_healing/bandage.lua
+++ b/mods/ctf/ctf_combat/ctf_healing/bandage.lua
@@ -66,6 +66,11 @@ function ctf_healing.register_bandage(name, def)
 						text = uname .. " healed you!",
 						color = 0xC1FF44,
 					})
+					hud_events.new(uname, {
+						quick = true,
+						text = "You healed "..pname.."!",
+						color = 0xC1FF44,
+					})
 				elseif type(result) == "string" then
 					hud_events.new(uname, {
 						quick = true,

--- a/mods/ctf/ctf_combat/ctf_healing/bandage.lua
+++ b/mods/ctf/ctf_combat/ctf_healing/bandage.lua
@@ -66,11 +66,6 @@ function ctf_healing.register_bandage(name, def)
 						text = uname .. " healed you!",
 						color = 0xC1FF44,
 					})
-					hud_events.new(uname, {
-						quick = true,
-						text = "You healed "..pname.."!",
-						color = 0xC1FF44,
-					})
 				elseif type(result) == "string" then
 					hud_events.new(uname, {
 						quick = true,

--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -372,6 +372,11 @@ local function end_combat_mode(player, reason, killer, weapon_image)
 
 		if ctf_teams.get(killer) then
 			ctf_kill_list.add(killer, player, weapon_image, comment)
+			hud_events.new(player, {
+				quick = false,
+				text = killer.." killed you for ".. rewards.score .." points!",
+				color = "warning",
+			})
 		end
 
 		-- share kill score with other hitters


### PR DESCRIPTION
- [x] This PR has been tested locally
- Based on suggestion [Discord](https://discord.com/channels/447819017391046687/1008040841102766153/1223829725793751092) , shows a HUD message to even healer that he is has healed the player. 
- Additionally based on suggestion [Discord](https://discord.com/channels/447819017391046687/1008040841102766153/1218686930833768612), shows a HUD message to player who died, that the killer got x points. 