### PR TITLE
Prevent item's special ability from activating during build time.

### DIFF
--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -144,6 +144,12 @@ ctf_melee.simple_register_sword("ctf_mode_classes:knight_sword", {
 			if not ctl.sneak and not ctl.aux1 then return end
 		end
 		if not ctf_modebase.match_started then
+			local uname = user:get_player_name()
+			hud_events.new(uname, {
+				quick = true,
+				text = "You cannot activate special ability during build time!",
+				color = "warning",
+			})
 			return
 		end
 		local pname = user:get_player_name()
@@ -219,6 +225,12 @@ ctf_ranged.simple_register_gun("ctf_mode_classes:ranged_rifle", {
 			return
 		end
 		if not ctf_modebase.match_started then
+			local uname = user:get_player_name()
+			hud_events.new(uname, {
+				quick = true,
+				text = "You cannot activate special ability during build time!",
+				color = "warning",
+			})
 			return
 		end
 		if itemstack:get_wear() == 0 then
@@ -302,6 +314,12 @@ ctf_healing.register_bandage("ctf_mode_classes:support_bandage", {
 		    if not ctl.sneak and not ctl.aux1 then return end
         end
 		if not ctf_modebase.match_started then
+			local uname = user:get_player_name()
+			hud_events.new(uname, {
+				quick = true,
+				text = "You cannot activate special ability during build time!",
+				color = "warning",
+			})
 			return
 		end
 		local pname = user:get_player_name()

--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -143,7 +143,9 @@ ctf_melee.simple_register_sword("ctf_mode_classes:knight_sword", {
 			local ctl = user:get_player_control()
 			if not ctl.sneak and not ctl.aux1 then return end
 		end
-
+		if not ctf_modebase.match_started then
+			return
+		end
 		local pname = user:get_player_name()
 
 		if itemstack:get_wear() == 0 then
@@ -216,7 +218,9 @@ ctf_ranged.simple_register_gun("ctf_mode_classes:ranged_rifle", {
 
 			return
 		end
-
+		if not ctf_modebase.match_started then
+			return
+		end
 		if itemstack:get_wear() == 0 then
 			grenades.throw_grenade("grenades:frag", 24, user)
 
@@ -297,7 +301,9 @@ ctf_healing.register_bandage("ctf_mode_classes:support_bandage", {
 		    local ctl = user:get_player_control()
 		    if not ctl.sneak and not ctl.aux1 then return end
         end
-
+		if not ctf_modebase.match_started then
+			return
+		end
 		local pname = user:get_player_name()
 
 		if itemstack:get_wear() == 0 then

--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -147,7 +147,7 @@ ctf_melee.simple_register_sword("ctf_mode_classes:knight_sword", {
 			local uname = user:get_player_name()
 			hud_events.new(uname, {
 				quick = true,
-				text = "You cannot activate special ability during build time!",
+				text = "You cannot activate special abilities during build time!",
 				color = "warning",
 			})
 			return
@@ -228,7 +228,7 @@ ctf_ranged.simple_register_gun("ctf_mode_classes:ranged_rifle", {
 			local uname = user:get_player_name()
 			hud_events.new(uname, {
 				quick = true,
-				text = "You cannot activate special ability during build time!",
+				text = "You cannot activate special abilities during build time!",
 				color = "warning",
 			})
 			return
@@ -317,7 +317,7 @@ ctf_healing.register_bandage("ctf_mode_classes:support_bandage", {
 			local uname = user:get_player_name()
 			hud_events.new(uname, {
 				quick = true,
-				text = "You cannot activate special ability during build time!",
+				text = "You cannot activate special abilities during build time!",
 				color = "warning",
 			})
 			return


### PR DESCRIPTION
- [x] This PR has been tested locally
- Based on suggestion [Discord](https://discord.com/channels/447819017391046687/1008040841102766153/1225663529756131370), now prevent users from activating diamond sword/granade/invincible mode during build time. 