### PR TITLE
Fix bug - Poison grenades deal no damage to enemies.

### DIFF
--- a/mods/pvp/grenades/grenades.lua
+++ b/mods/pvp/grenades/grenades.lua
@@ -205,7 +205,7 @@ local register_smoke_grenade = function(name, description, image, damage)
 								local dname = target:get_player_name()
 								local dteam = ctf_teams.get(dname)
 								if dname ~= pname and dteam ~= pteam then
-									target:punch(thrower, 1, {
+									target:punch(thrower, 10, {
 										damage_groups = {
 											fleshy = 1,
 											grenade = 1,

--- a/mods/pvp/grenades/grenades.lua
+++ b/mods/pvp/grenades/grenades.lua
@@ -205,9 +205,9 @@ local register_smoke_grenade = function(name, description, image, damage)
 								local dname = target:get_player_name()
 								local dteam = ctf_teams.get(dname)
 								if dname ~= pname and dteam ~= pteam then
-									target:punch(thrower, 10, {
+									target:punch(thrower, 1, {
 										damage_groups = {
-											fleshy = 1,
+											fleshy = 2,
 											grenade = 1,
 											poison_grenade = 1,
 										}


### PR DESCRIPTION
- [x] This PR has been tested locally
- Due to damage amount being very low, `1` instead of `10`, the poison grenade did not do damage at all to players. 
- Caused due to PR f847ac8