### PR TITLE
Show classes about info even during cooldown period. 

### DIFF
--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -564,13 +564,6 @@ function classes.show_class_formspec(player)
 				end
 			end,
 		})
-	-- else
-	-- 	hud_events.new(player, {
-	-- 		quick = true,
-	-- 		text = "You can only change your class every "..CLASS_SWITCH_COOLDOWN.." seconds",
-	-- 		color = "warning",
-	-- 	})
-	-- end
 end
 
 function classes.is_restricted_item(player, name)

--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -495,14 +495,14 @@ function classes.show_class_formspec(player)
 					c,
 				})
 				if not cooldowns:get(player) then
-				table.insert(out, {
-					"button_exit[%f,%f;%f,1;select_%s;%s]",
-					pad + (((form_x-(pad*2 + bw))) * sect),
-					form_y-0.5,
-					bw,
-					c,
-					context.class_props[c].name,
-				})
+					table.insert(out, {
+						"button_exit[%f,%f;%f,1;select_%s;%s]",
+						pad + (((form_x-(pad*2 + bw))) * sect),
+						form_y-0.5,
+						bw,
+						c,
+						context.class_props[c].name,
+					})
 				else
 					table.insert(out, {
 						"button[%f,%f;%f,1;select_%s;%s]",

--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -415,155 +415,155 @@ function classes.show_class_formspec(player)
 	player = PlayerObj(player)
 	if not player then return end
 
-		if ctf_modebase.current_mode ~= "classes" then return end
+	if ctf_modebase.current_mode ~= "classes" then return end
 
-		if dist_from_flag(player) > 5 then
-			hud_events.new(player, {
-				quick = true,
-				text = "You can only change class at your flag!",
-				color = "warning",
-			})
-			return
-		end
+	if dist_from_flag(player) > 5 then
+		hud_events.new(player, {
+			quick = true,
+			text = "You can only change class at your flag!",
+			color = "warning",
+		})
+		return
+	end
 
-		local pteam = ctf_teams.get(player)
+	local pteam = ctf_teams.get(player)
 
-		ctf_gui.show_formspec(player, "ctf_mode_classes:class_form", function(context)
-			local form_x, form_y = 12, 10
-			local pad = 0.3
+	ctf_gui.show_formspec(player, "ctf_mode_classes:class_form", function(context)
+		local form_x, form_y = 12, 10
+		local pad = 0.3
 
-			local bw = 3
+		local bw = 3
 
-			local class = context.class
-			local class_prop = context.class_props[class]
+		local class = context.class
+		local class_prop = context.class_props[class]
 
-			local out = {
-				"formspec_version[4]",
-				{"size[%f,%f]", form_x, form_y+1.1},
-				"real_coordinates[true]",
-				{"hypertext[0,0.2;%f,1.6;title;<big><center><b>Class Info: %s</b></center></big>]", form_x, class_prop.name},
+		local out = {
+			"formspec_version[4]",
+			{"size[%f,%f]", form_x, form_y+1.1},
+			"real_coordinates[true]",
+			{"hypertext[0,0.2;%f,1.6;title;<big><center><b>Class Info: %s</b></center></big>]", form_x, class_prop.name},
 
-				{"box[%s,1.2;%f,%f;#00000077]", pad, ((form_x/2)-0.7) - pad, form_y-2.4},
-				{"model[%s,1.4;%f,%f;classpreview;character.b3d;%s,blank.png;{0,160};;;]",
-					pad,
-					((form_x/2)-0.7) - pad,
-					form_y-2.6,
-					ctf_cosmetics.get_colored_skin(context.player, context.pteam and ctf_teams.team[context.pteam].color) ..
-							context.classes.get_skin_overlay(class, true) or ""
-				},
-				{[[hypertext[%f,1.2;%f,%f;info;<global margin=20 font=mono background=#00000044>
-					</b>
-					<center>%s</center>
+			{"box[%s,1.2;%f,%f;#00000077]", pad, ((form_x/2)-0.7) - pad, form_y-2.4},
+			{"model[%s,1.4;%f,%f;classpreview;character.b3d;%s,blank.png;{0,160};;;]",
+				pad,
+				((form_x/2)-0.7) - pad,
+				form_y-2.6,
+				ctf_cosmetics.get_colored_skin(context.player, context.pteam and ctf_teams.team[context.pteam].color) ..
+						context.classes.get_skin_overlay(class, true) or ""
+			},
+			{[[hypertext[%f,1.2;%f,%f;info;<global margin=20 font=mono background=#00000044>
+				</b>
+				<center>%s</center>
 
 
-					<img name=heart.png width=20 float=left> %d HP
-					%s
-					Special items
-					%s
-					Disallowed Items
-					%s
-					] ]],
-					(form_x/2)-0.6,
-					(form_x/2)+0.6 - pad,
-					form_y-2.4,
-					class_prop.description,
-					class_prop.hp_max or minetest.PLAYER_MAX_HP_DEFAULT,
-					class_prop.physics and class_prop.physics.speed and
-							"<img name=sprint_stamina_icon.png width=20 float=left> "..class_prop.physics.speed.."x Speed\n" or "",
-					class_prop.items_markup,
-					class_prop.disallowed_items_markup
-				},
-			}
+				<img name=heart.png width=20 float=left> %d HP
+				%s
+				Special items
+				%s
+				Disallowed Items
+				%s
+				] ]],
+				(form_x/2)-0.6,
+				(form_x/2)+0.6 - pad,
+				form_y-2.4,
+				class_prop.description,
+				class_prop.hp_max or minetest.PLAYER_MAX_HP_DEFAULT,
+				class_prop.physics and class_prop.physics.speed and
+						"<img name=sprint_stamina_icon.png width=20 float=left> "..class_prop.physics.speed.."x Speed\n" or "",
+				class_prop.items_markup,
+				class_prop.disallowed_items_markup
+			},
+		}
 
-			local tb = #context.class_list -- total buttons
-			for i, c in pairs(context.class_list) do
-				local sect = (i-1)/(tb-1)
-				local font_color = "#ffffff"
-				if cooldowns:get(player) then
-					font_color = "#f23f42"
-					table.insert(out,
-						{"tooltip[select_%s;You can only change your class every "..CLASS_SWITCH_COOLDOWN.." seconds, ]", c}
-					)
-				end
-				table.insert(out, {
-					"style[select_%s;textcolor=".. font_color ..
-					";font_size=*1.4;content_offset=-%f,0;bgcolor="..context.class_props[c].color.."]" ..
-					"style[show_%s;padding=8,8;bgcolor="..context.class_props[c].color.."]",
-					c,
-					20 + 8,
-					c,
-				})
-				if not cooldowns:get(player) then
-					table.insert(out, {
-						"button_exit[%f,%f;%f,1;select_%s;%s]",
-						pad + (((form_x-(pad*2 + bw))) * sect),
-						form_y-0.5,
-						bw,
-						c,
-						context.class_props[c].name,
-					})
-				else
-					table.insert(out, {
-						"button[%f,%f;%f,1;select_%s;%s]",
-						pad + (((form_x-(pad*2 + bw))) * sect),
-						form_y-0.5,
-						bw,
-						c,
-						context.class_props[c].name,
-					})
-				end
-				table.insert(out, {
-					"image_button[%f,%f;1,1;settings_info.png;show_%s;]",
-					pad + (((form_x-(pad*2 + bw))) * sect) + bw - 1,
-					form_y-0.5,
-					c,
-				})
+		local tb = #context.class_list -- total buttons
+		for i, c in pairs(context.class_list) do
+			local sect = (i-1)/(tb-1)
+			local font_color = "#ffffff"
+			if cooldowns:get(player) then
+				font_color = "#f23f42"
 				table.insert(out,
-					{"tooltip[show_%s;Click to show class info]", c}
+					{"tooltip[select_%s;You can only change your class every "..CLASS_SWITCH_COOLDOWN.." seconds, ]", c}
 				)
 			end
-			return ctf_gui.list_to_formspec_str(out)
-		end, {
-			classes = classes,
-			player = player,
-			pteam = pteam,
-			wrap_class = wrap_class,
-			class_list = class_list,
-			class_props = class_props,
-			class = classes.get_name(player) or "knight",
-			_on_formspec_input = function(pname, context, fields)
-				if ctf_modebase.current_mode ~= "classes" then return end
+			table.insert(out, {
+				"style[select_%s;textcolor=".. font_color ..
+				";font_size=*1.4;content_offset=-%f,0;bgcolor="..context.class_props[c].color.."]" ..
+				"style[show_%s;padding=8,8;bgcolor="..context.class_props[c].color.."]",
+				c,
+				20 + 8,
+				c,
+			})
+			if not cooldowns:get(player) then
+				table.insert(out, {
+					"button_exit[%f,%f;%f,1;select_%s;%s]",
+					pad + (((form_x-(pad*2 + bw))) * sect),
+					form_y-0.5,
+					bw,
+					c,
+					context.class_props[c].name,
+				})
+			else
+				table.insert(out, {
+					"button[%f,%f;%f,1;select_%s;%s]",
+					pad + (((form_x-(pad*2 + bw))) * sect),
+					form_y-0.5,
+					bw,
+					c,
+					context.class_props[c].name,
+				})
+			end
+			table.insert(out, {
+				"image_button[%f,%f;1,1;settings_info.png;show_%s;]",
+				pad + (((form_x-(pad*2 + bw))) * sect) + bw - 1,
+				form_y-0.5,
+				c,
+			})
+			table.insert(out,
+				{"tooltip[show_%s;Click to show class info]", c}
+			)
+		end
+		return ctf_gui.list_to_formspec_str(out)
+	end, {
+		classes = classes,
+		player = player,
+		pteam = pteam,
+		wrap_class = wrap_class,
+		class_list = class_list,
+		class_props = class_props,
+		class = classes.get_name(player) or "knight",
+		_on_formspec_input = function(pname, context, fields)
+			if ctf_modebase.current_mode ~= "classes" then return end
 
-				if cooldowns:get(player) then
-					for _, class in pairs(context.class_list) do
-						if fields["select_"..class] then
-							context.class = class
-							return "refresh"
-						end
-					end
-				end
+			if cooldowns:get(player) then
 				for _, class in pairs(context.class_list) do
-					if fields["show_"..class] then
+					if fields["select_"..class] then
 						context.class = class
 						return "refresh"
 					end
-
-					if fields["select_"..class] then
-						if dist_from_flag(player) > 5 then
-							hud_events.new(player, {
-								quick = true,
-								text = "You can only change class at your flag!",
-								color = "warning",
-							})
-
-							return
-						end
-
-						select_class(pname, class)
-					end
 				end
-			end,
-		})
+			end
+			for _, class in pairs(context.class_list) do
+				if fields["show_"..class] then
+					context.class = class
+					return "refresh"
+				end
+
+				if fields["select_"..class] then
+					if dist_from_flag(player) > 5 then
+						hud_events.new(player, {
+							quick = true,
+							text = "You can only change class at your flag!",
+							color = "warning",
+						})
+
+						return
+					end
+
+					select_class(pname, class)
+				end
+			end
+		end,
+	})
 end
 
 function classes.is_restricted_item(player, name)

--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -481,7 +481,7 @@ function classes.show_class_formspec(player)
 				local sect = (i-1)/(tb-1)
 				local font_color = "#ffffff"
 				if cooldowns:get(player) then
-					font_color = "#ff0000"
+					font_color = "#f23f42"
 					table.insert(out,
 						{"tooltip[select_%s;You can only change your class every "..CLASS_SWITCH_COOLDOWN.." seconds, ]", c}
 					)

--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -415,7 +415,6 @@ function classes.show_class_formspec(player)
 	player = PlayerObj(player)
 	if not player then return end
 
-	-- if not cooldowns:get(player) then
 		if ctf_modebase.current_mode ~= "classes" then return end
 
 		if dist_from_flag(player) > 5 then

--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -487,7 +487,8 @@ function classes.show_class_formspec(player)
 					)
 				end
 				table.insert(out, {
-					"style[select_%s;textcolor="..font_color..";font_size=*1.4;content_offset=-%f,0;bgcolor="..context.class_props[c].color.."]" ..
+					"style[select_%s;textcolor=".. font_color ..
+					";font_size=*1.4;content_offset=-%f,0;bgcolor="..context.class_props[c].color.."]" ..
 					"style[show_%s;padding=8,8;bgcolor="..context.class_props[c].color.."]",
 					c,
 					20 + 8,


### PR DESCRIPTION
- [x] This PR has been tested locally
- Based on suggestion on [Discord](https://discord.com/channels/447819017391046687/1008040841102766153/1256239448245669978) shows the  classes info even if the player is in cooldown. 
- If in cooldown period, the regular `button_exit` is replaced with `button` with red text, and it shows the classes info instead of switching you to the class. (Similar behaviour as info button) 
![image](https://github.com/MT-CTF/capturetheflag/assets/64828294/eaf0426c-23fe-4093-baa3-bd7dec908599)
