### PR TITLE
Update ranking_commands.lua

### DIFF
--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -172,7 +172,7 @@ minetest.register_chatcommand("donate", {
 				time_diff % 60)
 		end
 
-		dmessage = (dmessage and dmessage ~= "") and (":" .. dmessage) or ""
+		dmessage = (dmessage and dmessage ~= "") and (": " .. dmessage) or ""
 
 
 		current_mode.recent_rankings.add(name, {score=-scoretotal}, true)


### PR DESCRIPTION
Just added a space in /donate's dmessage so that description becomes "donated 5 score to player1 and player2: good job" instead of "donated 5 score to player1 and player2:good job"



- [x] This PR has been tested locally
