### PR TITLE
Team chat modification

### DIFF
--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -80,7 +80,7 @@ minetest.register_chatcommand("t", {
 			local tcolor = ctf_teams.team[tname].color
 			for username in pairs(ctf_teams.online_players[tname].players) do
 				minetest.chat_send_player(username,
-						minetest.colorize(tcolor, "[TEAM] <" .. name .. "> " .. param .. "" ))
+						minetest.colorize(tcolor, "[TEAM] <" .. name .. "> " .. param ))
 			end
 		else
 			minetest.chat_send_player(name,

--- a/mods/ctf/ctf_chat/init.lua
+++ b/mods/ctf/ctf_chat/init.lua
@@ -80,7 +80,7 @@ minetest.register_chatcommand("t", {
 			local tcolor = ctf_teams.team[tname].color
 			for username in pairs(ctf_teams.online_players[tname].players) do
 				minetest.chat_send_player(username,
-						minetest.colorize(tcolor, "<" .. name .. "> ** " .. param .. " **"))
+						minetest.colorize(tcolor, "[TEAM] <" .. name .. "> " .. param .. "" ))
 			end
 		else
 			minetest.chat_send_player(name,


### PR DESCRIPTION
- [ x ] This PR has been tested locally
- Suggestion : my
- This mod just modifies the way a team message appears: it's no longer "<player> **Hello team**" but " [TEAM]<player> Hello team". 
