### PR TITLE
Fix treasure chest chat spam

### DIFF
--- a/mods/ctf/ctf_map/nodes.lua
+++ b/mods/ctf/ctf_map/nodes.lua
@@ -205,8 +205,15 @@ local chest_def = {
 	end,
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 		if player then
-			minetest.chat_send_player(player:get_player_name(),
-				"You're not allowed to put things in treasure chests!")
+			local meta = player:get_meta()
+			local last_time_warned = meta:get_int("last_chest_time_warned")
+			local current_time = minetest.get_gametime()
+
+			if current_time - last_time_warned > 0.01 then
+				minetest.chat_send_player(player:get_player_name(),
+					"You're not allowed to put things in treasure chests!")
+				meta:set_int("last_chest_time_warned", current_time)
+			end
 			return 0
 		end
 	end,


### PR DESCRIPTION
Fix spammed messages sent to player when adding an item into treasure chest using Shift+ Item



- [x] This PR has been tested locally
