### PR TITLE
Sound volume of flags

### DIFF
--- a/mods/apis/ctf_settings/init.lua
+++ b/mods/apis/ctf_settings/init.lua
@@ -138,7 +138,6 @@ minetest.register_on_mods_loaded(function()
 					lastypos = lastypos + 0.5
 				end
 			end
-			end
 
 			local form = {
 			{"box[-0.1,-0.1;%f,%f;#00000055]", FORMSIZE.x - SCROLLBAR_W, FORMSIZE.y},

--- a/mods/apis/ctf_settings/init.lua
+++ b/mods/apis/ctf_settings/init.lua
@@ -116,9 +116,17 @@ minetest.register_on_mods_loaded(function()
 					}
 					lastypos = lastypos + 0.6
 				elseif settingdef.type == "bar" then
-					lastypos = lastypos + 0.3
+					lastypos = lastypos + 0.7
 					setting_list[k] = {
-						"scrollbar[0,%f;%f,0.4;horizontal;%s;%s]tooltip[0,%f;%f,0.4;%s]",
+						"label[0,%f;%s]"..
+						"scrollbaroptions[min=%d;max=%d;smallstep=%d]"..
+						"scrollbar[0,%f;%f,0.4;horizontal;%s;%s]"..
+						"tooltip[0,%f;%f,0.4;%s]",
+						lastypos - 0.5,
+						settingdef.label or HumanReadable(setting),
+						settingdef.min or 0,
+						settingdef.max or 100,
+						settingdef.step or 20,
 						lastypos,
 						FORMSIZE.x - SCROLLBAR_W -2,
 						setting,
@@ -127,8 +135,9 @@ minetest.register_on_mods_loaded(function()
 						FORMSIZE.x,
 						settingdef.description or HumanReadable(setting),
 					}
-					lastypos = lastypos + 0.6
+					lastypos = lastypos + 0.5
 				end
+			end
 			end
 
 			local form = {

--- a/mods/apis/ctf_settings/init.lua
+++ b/mods/apis/ctf_settings/init.lua
@@ -115,6 +115,19 @@ minetest.register_on_mods_loaded(function()
 						settingdef.description or HumanReadable(setting),
 					}
 					lastypos = lastypos + 0.6
+				elseif settingdef.type == "bar" then
+					lastypos = lastypos + 0.3
+					setting_list[k] = {
+						"scrollbar[0,%f;%f,0.4;horizontal;%s;%s]tooltip[0,%f;%f,0.4;%s]",
+						lastypos,
+						FORMSIZE.x - SCROLLBAR_W -2,
+						setting,
+						context.setting[setting],
+						lastypos,
+						FORMSIZE.x,
+						settingdef.description or HumanReadable(setting),
+					}
+					lastypos = lastypos + 0.6
 				end
 			end
 
@@ -166,6 +179,19 @@ minetest.register_on_mods_loaded(function()
 
 							if setting.on_change then
 								setting.on_change(player, tostring(idx))
+							end
+
+							refresh = true
+						end
+					elseif setting.type == "bar" then
+						local scrollevent = minetest.explode_scrollbar_event(value)
+
+						if scrollevent.value and context.setting[field] ~= tostring(scrollevent.value) then
+							context.setting[field] = tostring(scrollevent.value)
+							ctf_settings.set(player, field, tostring(scrollevent.value))
+
+							if setting.on_change then
+								setting.on_change(player, tostring(scrollevent.value))
 							end
 
 							refresh = true

--- a/mods/apis/ctf_settings/init.lua
+++ b/mods/apis/ctf_settings/init.lua
@@ -120,8 +120,7 @@ minetest.register_on_mods_loaded(function()
 					setting_list[k] = {
 						"label[0,%f;%s]"..
 						"scrollbaroptions[min=%d;max=%d;smallstep=%d]"..
-						"scrollbar[0,%f;%f,0.4;horizontal;%s;%s]"..
-						"tooltip[0,%f;%f,0.4;%s]",
+						"scrollbar[0,%f;%f,0.4;horizontal;%s;%s]",
 						lastypos - 0.5,
 						settingdef.label or HumanReadable(setting),
 						settingdef.min or 0,
@@ -131,9 +130,6 @@ minetest.register_on_mods_loaded(function()
 						FORMSIZE.x - SCROLLBAR_W -2,
 						setting,
 						context.setting[setting],
-						lastypos,
-						FORMSIZE.x,
-						settingdef.description or HumanReadable(setting),
 					}
 					lastypos = lastypos + 0.5
 				end

--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -301,7 +301,7 @@ local function celebrate_team(teamname)
 	for _, player in ipairs(minetest.get_connected_players()) do
 		local pname = player:get_player_name()
 		local pteam = ctf_teams.get(pname)
-		local volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) / 100 or 1.0
+		local volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) or 1.0
 
 		if pteam == teamname then
 			minetest.sound_play("ctf_modebase_trumpet_positive", {

--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -302,7 +302,7 @@ local function celebrate_team(teamname)
 		local pname = player:get_player_name()
 		local pteam = ctf_teams.get(pname)
 		local volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) / 1000 or 1.0
-		
+
 		if pteam == teamname then
 			minetest.sound_play("ctf_modebase_trumpet_positive", {
 				to_player = pname,

--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -301,7 +301,7 @@ local function celebrate_team(teamname)
 	for _, player in ipairs(minetest.get_connected_players()) do
 		local pname = player:get_player_name()
 		local pteam = ctf_teams.get(pname)
-		local volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) / 1000 or 1.0
+		local volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) / 100 or 1.0
 
 		if pteam == teamname then
 			minetest.sound_play("ctf_modebase_trumpet_positive", {
@@ -323,7 +323,7 @@ local function drop_flag(teamname)
 	for _, player in ipairs(minetest.get_connected_players()) do
 		local pname = player:get_player_name()
 		local pteam = ctf_teams.get(pname)
-		local drop_volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) / 1000 or 1.0
+		local drop_volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) / 100 or 0.2
 
 		if pteam then
 			if pteam == teamname then

--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -301,17 +301,18 @@ local function celebrate_team(teamname)
 	for _, player in ipairs(minetest.get_connected_players()) do
 		local pname = player:get_player_name()
 		local pteam = ctf_teams.get(pname)
-
+		local volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) / 1000 or 1.0
+		
 		if pteam == teamname then
 			minetest.sound_play("ctf_modebase_trumpet_positive", {
 				to_player = pname,
-				gain = 1.0,
+				gain = volume,
 				pitch = 1.0,
 			}, true)
 		else
 			minetest.sound_play("ctf_modebase_trumpet_negative", {
 				to_player = pname,
-				gain = 1.0,
+				gain = volume,
 				pitch = 1.0,
 			}, true)
 		end
@@ -322,18 +323,19 @@ local function drop_flag(teamname)
 	for _, player in ipairs(minetest.get_connected_players()) do
 		local pname = player:get_player_name()
 		local pteam = ctf_teams.get(pname)
+		local drop_volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) / 1000 or 1.0
 
 		if pteam then
 			if pteam == teamname then
 				minetest.sound_play("ctf_modebase_drop_flag_negative", {
 					to_player = pname,
-					gain = 0.2,
+					gain = drop_volume,
 					pitch = 1.0,
 				}, true)
 			else
 				minetest.sound_play("ctf_modebase_drop_flag_positive", {
 					to_player = pname,
-					gain = 0.2,
+					gain = drop_volume,
 					pitch = 1.0,
 				}, true)
 			end

--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -323,7 +323,7 @@ local function drop_flag(teamname)
 	for _, player in ipairs(minetest.get_connected_players()) do
 		local pname = player:get_player_name()
 		local pteam = ctf_teams.get(pname)
-		local drop_volume = tonumber(ctf_settings.get(player, "flag_sound_volume")) / 100 or 0.2
+		local drop_volume = math.max(0.6, tonumber(ctf_settings.get(player, "flag_sound_volume")) or 1.0) - 0.5
 
 		if pteam then
 			if pteam == teamname then

--- a/mods/ctf/ctf_modebase/player.lua
+++ b/mods/ctf/ctf_modebase/player.lua
@@ -16,6 +16,7 @@ ctf_settings.register("auto_trash_stone_tools", {
 
 ctf_settings.register("flag_sound_volume", {
 	type = "bar",
+	label = "Flag Sound Volume",
 	description = "Adjust the flag sound volume",
 	default = "90",
 	min = 0,

--- a/mods/ctf/ctf_modebase/player.lua
+++ b/mods/ctf/ctf_modebase/player.lua
@@ -17,7 +17,10 @@ ctf_settings.register("auto_trash_stone_tools", {
 ctf_settings.register("flag_sound_volume", {
 	type = "bar",
 	description = "Adjust the flag sound volume",
-	default = "900",
+	default = "90",
+	min = 0,
+	max = 100,
+	step = 20,
 })
 
 local simplify_for_saved_stuff = function(iname)

--- a/mods/ctf/ctf_modebase/player.lua
+++ b/mods/ctf/ctf_modebase/player.lua
@@ -17,7 +17,6 @@ ctf_settings.register("auto_trash_stone_tools", {
 ctf_settings.register("flag_sound_volume", {
 	type = "bar",
 	label = "Flag Sound Volume",
-	description = "Adjust the flag sound volume",
 	default = "90",
 	min = 0,
 	max = 100,

--- a/mods/ctf/ctf_modebase/player.lua
+++ b/mods/ctf/ctf_modebase/player.lua
@@ -17,10 +17,10 @@ ctf_settings.register("auto_trash_stone_tools", {
 ctf_settings.register("flag_sound_volume", {
 	type = "bar",
 	label = "Flag Sound Volume",
-	default = "90",
+	default = "1",
 	min = 0,
-	max = 100,
-	step = 20,
+	max = 2,
+	step = 0.1,
 })
 
 local simplify_for_saved_stuff = function(iname)

--- a/mods/ctf/ctf_modebase/player.lua
+++ b/mods/ctf/ctf_modebase/player.lua
@@ -14,6 +14,12 @@ ctf_settings.register("auto_trash_stone_tools", {
 	default = "false"
 })
 
+ctf_settings.register("flag_sound_volume", {
+	type = "bar",
+	description = "Adjust the flag sound volume",
+	default = "900",
+})
+
 local simplify_for_saved_stuff = function(iname)
 	if not iname or iname == "" then return iname end
 


### PR DESCRIPTION

- [ ] This PR has been tested locally.

Add a setting to adjust the sound volume of a flag.

It allows the player to configure their flag sound volume using a horizontal scroll bar.
