### PR TITLE
Fix two problems with returning dropped items

### DIFF
--- a/mods/ctf/ctf_teams/team_chest.lua
+++ b/mods/ctf/ctf_teams/team_chest.lua
@@ -5,7 +5,6 @@ local blacklist = {
 	"default:pick_stone",
 }
 
---[[
 local item_value = {
 	["grenades:poison"] = 5,
 	["grenades:frag"] = 6,
@@ -52,15 +51,12 @@ local item_value = {
 	["ctf_healing:medkit"] = 6,
 	["ctf_healing:bandage"] = 6,
 }
---]]
-
-
-
-
 
 local function get_chest_access(name)
 	local current_mode = ctf_modebase:get_current_mode()
-	if not current_mode then return false, false end
+	if not current_mode then
+		return false, false
+	end
 
 	return current_mode.get_chest_access(name)
 end
@@ -84,12 +80,12 @@ for _, team in ipairs(ctf_teams.teamlist) do
 		local chestcolor = ctf_teams.team[team].color
 		local function get_chest_texture(chest_side, color, mask, extra)
 			return string.format(
-				"(default_chest_%s.png" ..
-				"^[colorize:%s:130)" ..
-				"^(default_chest_%s.png" ..
-				"^[mask:ctf_teams_chest_%s_mask.png" ..
-				"^[colorize:%s:60)" ..
-				"%s",
+				"(default_chest_%s.png"
+					.. "^[colorize:%s:130)"
+					.. "^(default_chest_%s.png"
+					.. "^[mask:ctf_teams_chest_%s_mask.png"
+					.. "^[colorize:%s:60)"
+					.. "%s",
 				chest_side,
 				color,
 				chest_side,
@@ -100,7 +96,7 @@ for _, team in ipairs(ctf_teams.teamlist) do
 		end
 
 		local def = {
-			description = HumanReadable(team).." Team's Chest",
+			description = HumanReadable(team) .. " Team's Chest",
 			tiles = {
 				get_chest_texture("top", chestcolor, "top"),
 				get_chest_texture("top", chestcolor, "top"),
@@ -110,7 +106,7 @@ for _, team in ipairs(ctf_teams.teamlist) do
 				get_chest_texture("front", chestcolor, "side", "^ctf_teams_lock.png"),
 			},
 			paramtype2 = "facedir",
-			groups = {immortal = 1, team_chest=1},
+			groups = { immortal = 1, team_chest = 1 },
 			legacy_facedir_simple = true,
 			is_ground_content = false,
 			sounds = default.node_sound_wood_defaults(),
@@ -118,7 +114,10 @@ for _, team in ipairs(ctf_teams.teamlist) do
 
 		function def.on_construct(pos)
 			local meta = minetest.get_meta(pos)
-			meta:set_string("infotext", string.format("%s Team's Chest", HumanReadable(team)))
+			meta:set_string(
+				"infotext",
+				string.format("%s Team's Chest", HumanReadable(team))
+			)
 
 			local inv = meta:get_inventory()
 			inv:set_size("main", 6 * 7)
@@ -145,7 +144,7 @@ for _, team in ipairs(ctf_teams.teamlist) do
 
 			local formspec = table.concat({
 				"size[10,12]",
-				default.get_hotbar_bg(1,7.85),
+				default.get_hotbar_bg(1, 7.85),
 				"list[current_player;main;1,7.85;8,1;]",
 				"list[current_player;main;1,9.08;8,3;8]",
 			}, "")
@@ -158,12 +157,15 @@ for _, team in ipairs(ctf_teams.teamlist) do
 			end
 
 			if reg_access ~= true then
-				formspec = formspec .. "label[0.75,3;" ..
-					minetest.formspec_escape(minetest.wrap_text(
-						reg_access or "You aren't allowed to access the team chest",
-						60
-					)) ..
-				"]"
+				formspec = formspec
+					.. "label[0.75,3;"
+					.. minetest.formspec_escape(
+						minetest.wrap_text(
+							reg_access or "You aren't allowed to access the team chest",
+							60
+						)
+					)
+					.. "]"
 
 				minetest.show_formspec(name, "ctf_teams:no_access", formspec)
 				return
@@ -171,33 +173,56 @@ for _, team in ipairs(ctf_teams.teamlist) do
 
 			local chestinv = "nodemeta:" .. pos.x .. "," .. pos.y .. "," .. pos.z
 
-			formspec = formspec .. "list[" .. chestinv .. ";main;0,0.3;6,7;]" ..
-				"background[6,-0.2;4.15,7.7;ctf_map_pro_section.png;false]"
+			formspec = formspec
+				.. "list["
+				.. chestinv
+				.. ";main;0,0.3;6,7;]"
+				.. "background[6,-0.2;4.15,7.7;ctf_map_pro_section.png;false]"
 
 			if pro_access == true then
-				formspec = formspec .. "list[" .. chestinv .. ";pro;6,0.3;4,7;]" ..
-					"listring[" .. chestinv ..";pro]" ..
-					"listring[" .. chestinv .. ";helper]" ..
-					"label[7,-0.2;" ..
-					minetest.formspec_escape("Pro players only") .. "]"
+				formspec = formspec
+					.. "list["
+					.. chestinv
+					.. ";pro;6,0.3;4,7;]"
+					.. "listring["
+					.. chestinv
+					.. ";pro]"
+					.. "listring["
+					.. chestinv
+					.. ";helper]"
+					.. "label[7,-0.2;"
+					.. minetest.formspec_escape("Pro players only")
+					.. "]"
 			else
-				formspec = formspec .. "label[6.5,2;" ..
-					minetest.formspec_escape(minetest.wrap_text(
-						pro_access or "You aren't allowed to access the pro section",
-						20
-					)) ..
-				"]"
+				formspec = formspec
+					.. "label[6.5,2;"
+					.. minetest.formspec_escape(
+						minetest.wrap_text(
+							pro_access or "You aren't allowed to access the pro section",
+							20
+						)
+					)
+					.. "]"
 			end
 
-			formspec = formspec ..
-				"listring[" .. chestinv ..";main]" ..
-				"listring[current_player;main]"
+			formspec = formspec
+				.. "listring["
+				.. chestinv
+				.. ";main]"
+				.. "listring[current_player;main]"
 
-			minetest.show_formspec(name, "ctf_teams:chest",  formspec)
+			minetest.show_formspec(name, "ctf_teams:chest", formspec)
 		end
 
-		function def.allow_metadata_inventory_move(pos, from_list, from_index,
-				to_list, to_index, count, player)
+		function def.allow_metadata_inventory_move(
+			pos,
+			from_list,
+			from_index,
+			to_list,
+			to_index,
+			count,
+			player
+		)
 			local name = player:get_player_name()
 
 			if team ~= ctf_teams.get(name) then
@@ -211,10 +236,13 @@ for _, team in ipairs(ctf_teams.teamlist) do
 
 			local reg_access, pro_access = get_chest_access(name)
 
-			if reg_access == true and (pro_access == true or from_list ~= "pro" and to_list ~= "pro") then
+			if
+				reg_access == true
+				and (pro_access == true or from_list ~= "pro" and to_list ~= "pro")
+			then
 				if to_list == "helper" then
 					-- handle move & overflow
-					local chestinv = minetest.get_inventory({type = "node", pos = pos})
+					local chestinv = minetest.get_inventory({ type = "node", pos = pos })
 					local playerinv = player:get_inventory()
 					local stack = chestinv:get_stack(from_list, from_index)
 					local leftover = playerinv:add_item("main", stack)
@@ -252,7 +280,7 @@ for _, team in ipairs(ctf_teams.teamlist) do
 			local reg_access, pro_access = get_chest_access(name)
 
 			if reg_access == true and (pro_access == true or listname ~= "pro") then
-				local chestinv = minetest.get_inventory({type = "node", pos = pos})
+				local chestinv = minetest.get_inventory({ type = "node", pos = pos })
 				if chestinv:room_for_item("pro", stack) then
 					return stack:get_count()
 				else
@@ -299,36 +327,44 @@ for _, team in ipairs(ctf_teams.teamlist) do
 			end
 		end
 
-
-	function def.on_metadata_inventory_put(pos, listname, index, stack, player)
-		minetest.log("action", string.format("%s puts %s to team chest at %s",
-			player:get_player_name(),
-			stack:to_string(),
-			minetest.pos_to_string(pos)
-		))
-		local meta = stack:get_meta()
-		local dropped_by = meta:get_string("dropped_by")
-		local pname = player:get_player_name()
-		if dropped_by ~= pname and dropped_by ~= "" then
-			local cur_mode = ctf_modebase:get_current_mode()
-			if pname and cur_mode then
-				--local score = (item_value[stack:get_name()] or 0) * stack:get_count()
-				cur_mode.recent_rankings.add(pname, { score = 1 }, false)
+		function def.on_metadata_inventory_put(pos, listname, index, stack, player)
+			minetest.log(
+				"action",
+				string.format(
+					"%s puts %s to team chest at %s",
+					player:get_player_name(),
+					stack:to_string(),
+					minetest.pos_to_string(pos)
+				)
+			)
+			local meta = stack:get_meta()
+			local dropped_by = meta:get_string("dropped_by")
+			local pname = player:get_player_name()
+			if dropped_by ~= pname and dropped_by ~= "" then
+				local cur_mode = ctf_modebase:get_current_mode()
+				if pname and ctf_modebase.match_started then
+					local item_score = (item_value[stack:get_name()] or 1)
+						* stack:get_count()
+					cur_mode.recent_rankings.add(pname, { score = item_score }, false)
+				end
 			end
+			meta:set_string("dropped_by", "")
+			local inv = minetest.get_inventory({ type = "node", pos = pos })
+			local stack_ = inv:get_stack(listname, index)
+			stack_:get_meta():set_string("dropped_by", "")
+			inv:set_stack(listname, index, stack_)
 		end
-		meta:set_string("dropped_by", "")
-		local inv = minetest.get_inventory({ type="node", pos=pos })
-		local stack_ = inv:get_stack(listname,index)
-		stack_:get_meta():set_string("dropped_by", "")
-		inv:set_stack(listname, index, stack_)
-	end
 
 		function def.on_metadata_inventory_take(pos, listname, index, stack, player)
-			minetest.log("action", string.format("%s takes %s from team chest at %s",
-				player:get_player_name(),
-				stack:to_string(),
-				minetest.pos_to_string(pos)
-			))
+			minetest.log(
+				"action",
+				string.format(
+					"%s takes %s from team chest at %s",
+					player:get_player_name(),
+					stack:to_string(),
+					minetest.pos_to_string(pos)
+				)
+			)
 		end
 
 		minetest.register_node("ctf_teams:chest_" .. team, def)


### PR DESCRIPTION
- [x] This PR has been tested locally

 - Give score to a player for returning dropped items only when the match has started
 - Give score to a player for returning dropped items based on the value the item has