### PR TITLE
Fix bug in nametag bug fix

### DIFF
--- a/mods/other/playertag/init.lua
+++ b/mods/other/playertag/init.lua
@@ -174,7 +174,11 @@ minetest.register_entity("playertag:tag", {
 	on_punch = function() return true end,
 	on_deactivate = function(self, removal)
 		if not removal then
-			local player = self.object:get_parent()
+			local attachmentInfo = self.object:get_attach()
+			local player = nil
+			if attachmentInfo then
+				player = attachmentInfo.parent
+			end
 
 			if player and player:is_player() then
 				minetest.log("action", "Playertag for player "..player:get_player_name().." unloaded. Re-adding...")


### PR DESCRIPTION
A recent commit, "Attempt to fix nametag bug", commit id bff7fd0, introduced a bug which is fixed here.
The commit added some code to mods/other/playertag/init.lua, and in the code was a call to self.object:get_parent().
This function does not exist, and therefore the server would crash after the end of each match when it tried to call it.
This PR replaces self.object:get_parent() with an equivalent self.object:get_attach().
Since self.object:get_attach() works slightly differently than how self.object:get_parent() was supposed to work, a bit more code is added in to compensate.


- [x ] This PR has been tested locally
