### PR TITLE
Add touch_interaction to grenades

### DIFF
--- a/mods/ctf/ctf_modes/ctf_mode_nade_fight/tool.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_nade_fight/tool.lua
@@ -373,7 +373,8 @@ for idx, info in ipairs(grenade_list) do
 				return swap_next_grenade(itemstack, user, pointed)
 			end
 		end,
-		on_secondary_use = swap_next_grenade
+		on_secondary_use = swap_next_grenade,
+		touch_interaction = "short_dig_long_place", -- throw with short tap
 	})
 end
 

--- a/mods/pvp/grenades/init.lua
+++ b/mods/pvp/grenades/init.lua
@@ -145,6 +145,7 @@ function grenades.register_grenade(name, def)
 	newdef.description = def.description
 	newdef.stack_max = math.max(1, def.stack_max or 1)
 	newdef.inventory_image = def.image
+	newdef.touch_interaction = "short_dig_long_place" -- throw with short tap
 	local on_use = function(itemstack, user, pointed_thing)
 		if pointed_thing.type ~= "node" then
 			grenades.throw_grenade(name, 17, user)


### PR DESCRIPTION

- [x] This PR has been tested locally

throwing grenades with long tap means you can't move the camera for 400ms before throwing a grenade, so you can't aim properly

=> throw grenades with short tap instead