### PR TITLE
allow donating maximum score by donating 0 or less

### DIFF
--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -96,9 +96,8 @@ ctf_api.register_on_match_end(function()
 end)
 
 ctf_core.register_chatcommand_alias("donate", "d", {
-	description = [[Donate your match score to your teammate
-Can be used only once in 2.5 minutes
-Replace <score> with :max or any negative number to donate the maximum amount]],
+	description = "Donate your match score to your teammate\nCan be used only once in 2.5 minutes"..
+			"\nReplace <score> with :max or any negative number to donate the maximum amount",
 	params = "<name [name2 name3 ...]> <score> [message]",
 	func = function(name, param)
 		local current_mode = ctf_modebase:get_current_mode()

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -96,7 +96,7 @@ ctf_api.register_on_match_end(function()
 end)
 
 ctf_core.register_chatcommand_alias("donate", "d", {
-	description = "Donate your match score to your teammate\nCan be used only once in 2.5 minutes",
+	description = "Donate your match score to your teammate\nCan be used only once in 2.5 minutes\nReplace <score> with :max or any negative number to donate the maximum amount",
 	params = "<name [name2 name3 ...]> <score> [message]",
 	func = function(name, param)
 		local current_mode = ctf_modebase:get_current_mode()
@@ -113,6 +113,8 @@ ctf_core.register_chatcommand_alias("donate", "d", {
 				dmessage = dmessage .. " " .. p
 			elseif ctf_core.to_number(p) and score == 0 then
 				score = p
+			elseif p == ":max" and score == 0 then
+				score = -1
 			else
 				local team = ctf_teams.get(p)
 				if not team and pcount > 0 then
@@ -156,7 +158,7 @@ ctf_core.register_chatcommand_alias("donate", "d", {
 			(current_mode.rankings:get(name) or {}).score or 0
 		)
 
-		if score <= 0 then
+		if score < 0 then
 			score = math.floor(cur_score / 2 / pcount)
 		end
 

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -151,15 +151,21 @@ ctf_core.register_chatcommand_alias("donate", "d", {
 		end
 		score = math.floor(score)
 
+		local cur_score = math.min(
+			current_mode.recent_rankings.get(name).score or 0,
+			(current_mode.rankings:get(name) or {}).score or 0
+		)
+
+		if score <= 0 then
+			score = math.floor(cur_score / 2 / pcount)
+		end
+
 		if score < 5 then
 			return false, "You should donate at least 5 score!"
 		end
 
 		local scoretotal = score * pcount
-		local cur_score = math.min(
-			current_mode.recent_rankings.get(name).score or 0,
-			(current_mode.rankings:get(name) or {}).score or 0
-		)
+
 		if scoretotal > cur_score / 2 then
 			return false, "You can donate only half of your match score!"
 		end

--- a/mods/ctf/ctf_modebase/ranking_commands.lua
+++ b/mods/ctf/ctf_modebase/ranking_commands.lua
@@ -96,7 +96,9 @@ ctf_api.register_on_match_end(function()
 end)
 
 ctf_core.register_chatcommand_alias("donate", "d", {
-	description = "Donate your match score to your teammate\nCan be used only once in 2.5 minutes\nReplace <score> with :max or any negative number to donate the maximum amount",
+	description = [[Donate your match score to your teammate
+Can be used only once in 2.5 minutes
+Replace <score> with :max or any negative number to donate the maximum amount]],
 	params = "<name [name2 name3 ...]> <score> [message]",
 	func = function(name, param)
 		local current_mode = ctf_modebase:get_current_mode()


### PR DESCRIPTION

- [x] This PR has been tested locally

[Suggestion](https://discord.com/channels/447819017391046687/1008040841102766153/1288113654742519838)

This should allow players to donate half their score by using 0 or any negative number as the donation amount. I've tested it as well as I can.