### PR TITLE
Remove Landmines on Dig

### DIFF
--- a/mods/ctf/ctf_landmine/init.lua
+++ b/mods/ctf/ctf_landmine/init.lua
@@ -139,11 +139,11 @@ core.register_node("ctf_landmine:landmine", {
 		if not is_self_landmine(puncher, pos) then
 			landmine_explode(pos)
 		end
-	end
+	end,
 	on_dig = function(pos, node, digger)
         remove_landmine(pos)
         minetest.node_dig(pos, node, digger)
-    end,
+    end
 })
 
 core.register_globalstep(function(dtime)

--- a/mods/ctf/ctf_landmine/init.lua
+++ b/mods/ctf/ctf_landmine/init.lua
@@ -140,6 +140,10 @@ core.register_node("ctf_landmine:landmine", {
 			landmine_explode(pos)
 		end
 	end
+	on_dig = function(pos, node, digger)
+        remove_landmine(pos)
+        minetest.node_dig(pos, node, digger)
+    end,
 })
 
 core.register_globalstep(function(dtime)


### PR DESCRIPTION
This fixes the issue of "ghost landmines", i.e. when a landmine is dug, the node disappears, but the landmine is still there