### PR TITLE
Make landmine recipe cheaper

### DIFF
--- a/mods/ctf/ctf_modebase/crafting.lua
+++ b/mods/ctf/ctf_modebase/crafting.lua
@@ -176,6 +176,6 @@ crafting.register_recipe({
 
 crafting.register_recipe({
 	output = "ctf_landmine:landmine",
-	items  = { "default:steel_ingot 4", "grenades:frag" },
+	items  = { "default:steel_ingot 4", "ctf_map:damage_cobble" },
 	always_known = false,
 })


### PR DESCRIPTION
Makes Landmines craftable with damage cobble instead of frags. This makes then cheaper and also available to make in nade fight
- [ ] This PR has been tested locally
