### PR TITLE
Clay Blocks drop Clay Blocks and can be smelted into Brick Blocks

### DIFF
--- a/mods/mtg/ctf_changes/init.lua
+++ b/mods/mtg/ctf_changes/init.lua
@@ -202,6 +202,12 @@ minetest.override_item("default:clay", {
 	drop = "default:clay",
 })
 
+minetest.register_craft({
+	type = "cooking",
+	output = "default:brick",
+	recipe = "default:clay",
+})
+
 minetest.register_on_mods_loaded(function()
 	for nodename, value in pairs(node_fall_damage_factors) do
 		local groups_temp = minetest.registered_items[nodename].groups

--- a/mods/mtg/ctf_changes/init.lua
+++ b/mods/mtg/ctf_changes/init.lua
@@ -198,6 +198,10 @@ minetest.override_item("default:furnace_active", {
 	on_destruct = furnace_on_destruct,
 })
 
+minetest.override_item("default:clay", {
+	drop = "default:clay",
+})
+
 minetest.register_on_mods_loaded(function()
 	for nodename, value in pairs(node_fall_damage_factors) do
 		local groups_temp = minetest.registered_items[nodename].groups


### PR DESCRIPTION
Clay blocks drop themselves, instead of 4 lumps.
Clay blocks also now smelt into brick blcoks.
- [x] This PR has been tested locally
