### PR TITLE
don't replace ind_glass when placing outer barrier

### DIFF
--- a/mods/ctf/ctf_map/init.lua
+++ b/mods/ctf/ctf_map/init.lua
@@ -264,6 +264,7 @@ minetest.register_chatcommand("ctf_barrier", {
 								or z == pos1.z or z == pos2.z then
 								if data[vi] == minetest.get_content_id("air") or
 									data[vi] == minetest.get_content_id("ignore") or
+                                    data[vi] == minetest.get_content_id("ctf_map:ind_glass") or
 									data[vi] == minetest.get_content_id("ctf_map:ignore") then
 									data[vi] = minetest.get_content_id("ctf_map:ind_glass")
 								else


### PR DESCRIPTION
slimy_bannana_peel asked me to make this pr for him. It changes the ctf_barrier command to not replace ind_glass with stone when placing an outer barrier. 

- [x] This PR has been tested locally
