### PR TITLE
Custom AFK-Kick message

### DIFF
--- a/mods/other/afkkick/init.lua
+++ b/mods/other/afkkick/init.lua
@@ -45,6 +45,7 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 minetest.register_on_leaveplayer(function(player)
+	minetest.chat_send_all("*** " .. player:get_player_name() .. " left the game (inactivity)")
 	local playerName = player:get_player_name()
 	players[playerName] = nil
 end)


### PR DESCRIPTION
Sends the message "Player left the game (inactivity)" when the AFK timer kicks a player

- [x] This PR has been tested locally
