### PR TITLE
Prevent chest and locked chest usage

### DIFF
--- a/mods/mtg/ctf_changes/init.lua
+++ b/mods/mtg/ctf_changes/init.lua
@@ -208,6 +208,14 @@ minetest.register_craft({
 	recipe = "default:clay",
 })
 
+minetest.override_item("default:chest", {
+	on_rightclick = function() return end,
+})
+
+minetest.override_item("default:chest_locked", {
+	on_rightclick = function() return end,
+})
+
 minetest.register_on_mods_loaded(function()
 	for nodename, value in pairs(node_fall_damage_factors) do
 		local groups_temp = minetest.registered_items[nodename].groups

--- a/mods/mtg/ctf_changes/init.lua
+++ b/mods/mtg/ctf_changes/init.lua
@@ -214,6 +214,7 @@ minetest.override_item("default:chest", {
 
 minetest.override_item("default:chest_locked", {
 	on_rightclick = function() return end,
+	protected = false,
 })
 
 minetest.register_on_mods_loaded(function()

--- a/mods/mtg/mtg_default/chests.lua
+++ b/mods/mtg/mtg_default/chests.lua
@@ -340,7 +340,7 @@ default.chest.register_chest("default:chest_locked", {
 	sound_open = "default_chest_open",
 	sound_close = "default_chest_close",
 	groups = {choppy = 2, oddly_breakable_by_hand = 2},
-	protected = true,
+	-- protected = true,
 })
 
 minetest.register_craft({


### PR DESCRIPTION

- [ x ] This PR has been tested locally

Prevent players from using/implementing default minetest game locked chests and normal chests. Players can make a locked chest indestructible to other players if the chest is placed and owned by that player.