### PR TITLE
add the ctf_map equivalent of the nodes from mtg's vessels mod

### DIFF
--- a/mods/ctf/ctf_map/nodes.lua
+++ b/mods/ctf/ctf_map/nodes.lua
@@ -141,6 +141,7 @@ minetest.register_node("ctf_map:killnode", {
 local mod_prefixes = {
 	default = "";
 	stairs = "";
+	vessels = "";
 	wool = "wool_";
 	walls = "walls_";
 }


### PR DESCRIPTION
Add some missing `ctf_map` nodes: `ctf_map:shelf`, `ctf_map:steel_bottle`, `ctf_map:drinking_glass`, `ctf_map:glass_bottle`

This on discord: https://discord.com/channels/447819017391046687/1008040841102766153/1282036731603980319
- [x] This PR has been tested locally
