### PR TITLE
Fix medic healing.

### DIFF
--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -317,8 +317,8 @@ ctf_healing.register_bandage("ctf_mode_classes:support_bandage", {
 	inventory_overlay = "ctf_modebase_special_item.png",
 	wield_image = "ctf_healing_bandage.png",
 	heal_percent = HEAL_PERCENT,
-	heal_min = 4 * 10,
-	heal_max = 5 * 10,
+	heal_min = 40,
+	heal_max = 50,
 	rightclick_func = function(itemstack, user, pointed)
 		if ctf_settings.get(user, "ctf_mode_classes:simple_support_activate") ~= "true" then
 		    local ctl = user:get_player_control()

--- a/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/classes.lua
@@ -317,8 +317,8 @@ ctf_healing.register_bandage("ctf_mode_classes:support_bandage", {
 	inventory_overlay = "ctf_modebase_special_item.png",
 	wield_image = "ctf_healing_bandage.png",
 	heal_percent = HEAL_PERCENT,
-	heal_min = 4,
-	heal_max = 5,
+	heal_min = 4 * 10,
+	heal_max = 5 * 10,
 	rightclick_func = function(itemstack, user, pointed)
 		if ctf_settings.get(user, "ctf_mode_classes:simple_support_activate") ~= "true" then
 		    local ctl = user:get_player_control()


### PR DESCRIPTION

- [ ] This PR has been tested locally

Player HP was recently multiplied by 10 to permit finer-grained damage application; various damage sources thus had to also be multiplied by 10 to compensate. It seems that healing was missed, so this fixes it too. I didn't actually test this locally, but it's a pretty trivial change, and I followed the call chain and the logic checks out.

(Note that I wrote out `* 10` to make it more obvious that this scaling takes place.)