### PR TITLE
Fix display issues related to HP scaling.

### DIFF
--- a/mods/ctf/ctf_combat/ctf_healing/bandage.lua
+++ b/mods/ctf/ctf_combat/ctf_healing/bandage.lua
@@ -44,7 +44,7 @@ function ctf_healing.register_bandage(name, def)
 				if hp >= limit then
 					hud_events.new(uname, {
 						quick = true,
-						text = pname .. " " .. S("already has") .. " " .. limit .. " " .. S("HP!"),
+						text = pname .. " " .. S("already has") .. " " .. (limit / 10) .. " " .. S("HP!"),
 						color = "warning",
 					})
 					return

--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -1009,7 +1009,7 @@ return {
 		end
 
 		ctf_combat_mode.add_healer(patient, player, 60)
-		recent_rankings.add(player, {hp_healed = amount, score = score}, true)
+		recent_rankings.add(player, {hp_healed = math.round(amount / 10), score = score}, true)
 	end,
 	initial_stuff_item_levels = {
 		pick = function(item)


### PR DESCRIPTION

- [ ] This PR has been tested locally

Whilst playing, I noticed that a) the '\<player\> is already at %f HP' message had the HP scaled by 10, and b) that my HP healed stat was increasing more rapidly than it should have (10x more rapidly, actually). This should fix both those issues. Note that I rounded the number that goes into rankings to keep it an integer like everything else, but it could also be desirable to have it as a decimal value. Untested like before, but similarly trivial.